### PR TITLE
Introduce the queue and repeat mode in global player

### DIFF
--- a/src/lib/components/Track/Track.svelte
+++ b/src/lib/components/Track/Track.svelte
@@ -3,10 +3,13 @@
 	import TrackFooter from './TrackFooter.svelte';
 	import TrackHeader from './TrackHeader.svelte';
 	import type { TrackOverview } from '$lib/types/tracks';
+	import type { PlayerSource } from '$lib/player/player';
 
 	export let track: TrackOverview;
 	export let variant: 'featured' | 'compact' | 'album' = 'compact';
 	export let muted = false;
+	export let playlist: PlayerSource[] | null = null;
+	export let playlistIndex: number | null = null;
 
 	let coverDisplay: 'none' | 'default' | 'large';
 	let showAlbumName: boolean;
@@ -29,6 +32,8 @@
 		{showAlbumName}
 		latestResourceUrl={track.latest_resource_url}
 		latestVersionId={track.latest_version_id}
+		{playlist}
+		{playlistIndex}
 	/>
 
 	<TrackItemBody description={track.track_description} display={showDescription} />

--- a/src/lib/components/Track/TrackHeader.svelte
+++ b/src/lib/components/Track/TrackHeader.svelte
@@ -5,7 +5,9 @@
 		isPlaying as gIsPlaying,
 		isReady as gIsReady,
 		load as playerLoad,
-		toggle as playerToggle
+		toggle as playerToggle,
+		setQueue,
+		type PlayerSource
 	} from '$lib/player/player';
 	import Cover from './Cover.svelte';
 
@@ -18,6 +20,8 @@
 	export let latestResourceUrl: string | null = null;
 	export let latestVersionId: string | null = null;
 	export let showAlbumName = true;
+	export let playlist: PlayerSource[] | null = null;
+	export let playlistIndex: number | null = null;
 
 	let isReady = false;
 	let isPlaying = false;
@@ -28,16 +32,18 @@
 	async function toggle() {
 		if (!latestResourceUrl) return;
 		if ($gCurrent?.src !== latestResourceUrl) {
-			await playerLoad(
-				{
-					src: latestResourceUrl,
-					versionId: latestVersionId ?? undefined,
-					title: trackName,
-					trackId: trackId ?? undefined,
-					coverUrl: coverUrl ?? undefined
-				},
-				true
-			);
+			const source: PlayerSource = {
+				src: latestResourceUrl,
+				versionId: latestVersionId ?? undefined,
+				title: trackName,
+				trackId: trackId ?? undefined,
+				coverUrl: coverUrl ?? undefined
+			};
+			if (playlist && typeof playlistIndex === 'number' && playlistIndex >= 0) {
+				await setQueue(playlist, playlistIndex, true);
+			} else {
+				await playerLoad(source, true);
+			}
 		} else {
 			playerToggle();
 		}

--- a/src/lib/components/TrackVersionFooter.svelte
+++ b/src/lib/components/TrackVersionFooter.svelte
@@ -14,12 +14,12 @@
 	import PlayerControlButton from '$lib/components/PlayerControlButton.svelte';
 	import { t } from '$lib/i18n/i18n';
 	import {
-		load as playerLoad,
 		toggle as playerToggle,
 		isReady as gIsReady,
 		isPlaying as gIsPlaying,
 		current as gCurrent,
-		duration as gDuration
+		duration as gDuration,
+		setQueue
 	} from '$lib/player/player';
 
 	onMount(() => {});
@@ -38,7 +38,7 @@
 	async function toggle() {
 		if (!src) return;
 		if ($gCurrent?.src !== src) {
-			await playerLoad({ src, versionId: version_id, title, trackId, coverUrl }, true);
+			await setQueue([{ src, versionId: version_id, title, trackId, coverUrl }], 0, true);
 		} else {
 			playerToggle();
 		}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -8,7 +8,10 @@ import {
 	faHeart as fasHeart,
 	faThumbsUp as fasThumbsUp,
 	faSquareMinus as fasSquareMinus,
-	faClockRotateLeft
+	faClockRotateLeft,
+	faForwardStep,
+	faBackwardStep,
+	faRepeat
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -31,5 +34,8 @@ export const icons = {
 	thumbsUpRegular: farThumbsUp as IconDefinition,
 	squareMinus: fasSquareMinus as IconDefinition,
 	squareMinusRegular: farSquareMinus as IconDefinition,
-	clockRotateLeft: faClockRotateLeft as IconDefinition
+	clockRotateLeft: faClockRotateLeft as IconDefinition,
+	forwardStep: faForwardStep as IconDefinition,
+	backwardStep: faBackwardStep as IconDefinition,
+	repeat: faRepeat as IconDefinition
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,17 @@
 
 	$: featuredTrack = tracks[0];
 	$: otherTracks = tracks.slice(1, 4);
+	$: playableTracks = tracks.filter((t) => Boolean(t.latest_resource_url));
+	$: playlist = playableTracks.map((t) => ({
+		src: t.latest_resource_url as string,
+		versionId: t.latest_version_id ?? undefined,
+		title: t.track_name,
+		trackId: t.track_id,
+		coverUrl: t.album_cover_url ?? undefined
+	}));
+	$: playlistIndexByTrackId = Object.fromEntries(
+		playlist.map((item, idx) => [item.trackId, idx])
+	) as Record<string, number>;
 </script>
 
 <svelte:head>
@@ -37,11 +48,21 @@
 			<p class="empty">{$t('tracks.none')}</p>
 		{:else}
 			{#if featuredTrack}
-				<Track track={featuredTrack} variant="featured" />
+				<Track
+					track={featuredTrack}
+					variant="featured"
+					{playlist}
+					playlistIndex={playlistIndexByTrackId[featuredTrack.track_id] ?? null}
+				/>
 			{/if}
 			<div class="latests-list">
 				{#each otherTracks as track (track.track_id)}
-					<Track {track} variant="compact" />
+					<Track
+						{track}
+						variant="compact"
+						{playlist}
+						playlistIndex={playlistIndexByTrackId[track.track_id] ?? null}
+					/>
 				{/each}
 			</div>
 

--- a/src/routes/albums/[slug]/+page.svelte
+++ b/src/routes/albums/[slug]/+page.svelte
@@ -23,6 +23,17 @@
 
 	$: availableTracks = tracks.filter((t) => Boolean(t.latest_version_id));
 	$: upcomingTracks = tracks.filter((t) => !t.latest_version_id);
+	$: playableTracks = availableTracks.filter((t) => Boolean(t.latest_resource_url));
+	$: playlist = playableTracks.map((t) => ({
+		src: t.latest_resource_url as string,
+		versionId: t.latest_version_id ?? undefined,
+		title: t.track_name,
+		trackId: t.track_id,
+		coverUrl: t.album_cover_url ?? undefined
+	}));
+	$: playlistIndexByTrackId = Object.fromEntries(
+		playlist.map((item, idx) => [item.trackId, idx])
+	) as Record<string, number>;
 </script>
 
 <svelte:head>
@@ -63,7 +74,12 @@
 						<SectionHeading>{$t('tracks.available')}</SectionHeading>
 						<div class="album-tracks-list">
 							{#each availableTracks as track (track.track_id)}
-								<Track {track} variant="album" />
+								<Track
+									{track}
+									variant="album"
+									{playlist}
+									playlistIndex={playlistIndexByTrackId[track.track_id] ?? null}
+								/>
 							{/each}
 						</div>
 					</section>

--- a/src/routes/tracks/+page.svelte
+++ b/src/routes/tracks/+page.svelte
@@ -10,6 +10,17 @@
 
 	$: availableTracks = tracks.filter((t) => Boolean(t.latest_version_id));
 	$: upcomingTracks = tracks.filter((t) => !t.latest_version_id);
+	$: playableTracks = tracks.filter((t) => Boolean(t.latest_resource_url));
+	$: playlist = playableTracks.map((t) => ({
+		src: t.latest_resource_url as string,
+		versionId: t.latest_version_id ?? undefined,
+		title: t.track_name,
+		trackId: t.track_id,
+		coverUrl: t.album_cover_url ?? undefined
+	}));
+	$: playlistIndexByTrackId = Object.fromEntries(
+		playlist.map((item, idx) => [item.trackId, idx])
+	) as Record<string, number>;
 </script>
 
 <svelte:head>
@@ -33,7 +44,12 @@
 				<SectionHeading>{$t('tracks.available')}</SectionHeading>
 				<div class="tracks-list">
 					{#each availableTracks as track (track.track_id)}
-						<Track {track} variant="featured" />
+						<Track
+							{track}
+							variant="featured"
+							{playlist}
+							playlistIndex={playlistIndexByTrackId[track.track_id] ?? null}
+						/>
 					{/each}
 				</div>
 			</section>


### PR DESCRIPTION
Resolve #70 by introducing a queue, player control and repeat mode in the global player.

Added queue + repeat support (defaulting to repeat-all), hooked media-session prev/next, and wired page contexts into the shared player so playback keeps going and can loop.

- [x] Updated player core (src/lib/player/player.ts) with queue state, repeat modes, next/previous handlers, finish handling, and media session actions; load now sets a single-item queue; repeat-one/all logic drives autoplay.
- [x] Added new icons (src/lib/icons.ts) and global controls for prev/next/repeat in src/lib/components/GlobalPlayer.svelte, including a repeat-all/one/off toggle.
- [x] Track triggers now build queues: list/home/album pages create a playlist of playable tracks and pass playlist/playlistIndex into Track/TrackHeader (src/routes/+page.svelte, src/routes/tracks/+page.svelte, src/routes/albums/[slug]/+page.svelte, src/lib/components/Track/Track.svelte, src/lib/components/Track/TrackHeader.svelte); track detail versions enqueue only themselves (src/lib/components/TrackVersionFooter.svelte).