### PR TITLE
Re-implement Supabase Google auth and per-user likes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Home and Album pages.
 ## Stack
 
 - [Next.js 16](https://nextjs.org) (App Router, TypeScript, CSS Modules)
-- [Supabase](https://supabase.com) — read-only queries against `albums`,
-  `track_overview` (view) and `tracks` (lyrics); no authentication in step 1
+- [Supabase](https://supabase.com) — public content (`albums`, `track_overview`
+  view, `tracks` lyrics) plus Google sign-in and per-user likes
+  (`@supabase/ssr`)
 - [lucide-react](https://lucide.dev) icons
 - Fonts: Gloock (display) + Space Grotesk via `next/font`
 
@@ -35,6 +36,29 @@ timeline (wavesurfer.js) recolored per album palette, play/pause,
 next/previous, repeat (`all` by default), scrubbing, and MediaSession
 metadata + handlers for lock-screen controls on iOS/Android. Playback
 survives page navigation (the player lives above the router).
+
+## Accounts & likes
+
+- **Sign in with Google** from the account button (top-right on every page).
+  OAuth runs through Supabase Auth: the browser client starts the flow, Google
+  redirects back to `/auth/callback`, and the route handler exchanges the code
+  for a cookie session. `middleware.ts` keeps the session fresh.
+- **Likes** are per-user and persisted in the `track_likes` table. The heart on
+  each track toggles a row via the browser client (writes are guarded by
+  row-level security), with an optimistic count and rollback on failure. The
+  public catalog stays statically cached (ISR) — only the like state is resolved
+  client-side, so pages don't become per-user dynamic.
+- `/profile` shows the signed-in user and a sign-out control; `/likes` lists the
+  tracks the user has liked, most recent first.
+
+Supabase clients live in `src/lib/supabase/`: `anon.ts` (public read-only
+content), `client.ts` (browser, auth + likes) and `server.ts` (cookie-bound, for
+the callback route and the protected pages). The `track_likes` schema + RLS are
+in `supabase/migrations/20260710_track_likes.sql`.
+
+> The hosted project must have Google enabled as an auth provider and
+> `<site>/auth/callback` in its redirect allow-list. No extra environment
+> variables are needed beyond the two below.
 
 ## Development
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+/**
+ * Refreshes the Supabase auth session on every request so tokens stay valid
+ * and the refreshed cookies reach both the browser and any server client.
+ * Standard @supabase/ssr pattern — see supabase.com/docs/guides/auth/server-side/nextjs.
+ */
+export async function middleware(request: NextRequest) {
+  let response = NextResponse.next({ request });
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) =>
+          request.cookies.set(name, value)
+        );
+        response = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          response.cookies.set(name, value, options)
+        );
+      },
+    },
+  });
+
+  // Touch the session so expired access tokens get refreshed.
+  await supabase.auth.getUser();
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except static assets:
+     *   _next/static, _next/image, favicon.ico, and common image files.
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "melogram",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.110.2",
         "lucide-react": "^1.24.0",
         "next": "16.2.10",
@@ -1296,6 +1297,18 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.110.2",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.2.tgz",
@@ -2514,6 +2527,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.110.2",
     "lucide-react": "^1.24.0",
     "next": "16.2.10",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * OAuth redirect target. Exchanges the `?code` from Google (via Supabase)
+ * for a session, writing the auth cookies, then returns to `?next` or `/`.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      console.error("Supabase OAuth callback failed", error.message);
+      return NextResponse.redirect(`${origin}/?auth_error=1`);
+    }
+  }
+
+  // `next` is a relative path we control; keep it same-origin.
+  const safeNext = next.startsWith("/") ? next : "/";
+  return NextResponse.redirect(`${origin}${safeNext}`);
+}

--- a/src/app/auth/signout/route.ts
+++ b/src/app/auth/signout/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/** Clears the Supabase session cookies and returns home. */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  return NextResponse.redirect(new URL("/", request.url), { status: 303 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Gloock, Space_Grotesk } from "next/font/google";
 import { PlayerProvider } from "@/player/PlayerProvider";
 import PlayerBar from "@/components/PlayerBar";
+import AuthStatus from "@/components/AuthStatus";
+import { LikesProvider } from "@/components/LikesProvider";
 import "./globals.css";
 
 const gloock = Gloock({
@@ -29,10 +31,13 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${gloock.variable} ${spaceGrotesk.variable}`}>
       <body>
-        <PlayerProvider>
-          {children}
-          <PlayerBar />
-        </PlayerProvider>
+        <LikesProvider>
+          <PlayerProvider>
+            <AuthStatus />
+            {children}
+            <PlayerBar />
+          </PlayerProvider>
+        </LikesProvider>
       </body>
     </html>
   );

--- a/src/app/likes/page.module.css
+++ b/src/app/likes/page.module.css
@@ -1,0 +1,38 @@
+.page {
+  max-width: 1440px;
+  margin-inline: auto;
+  padding: 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.content {
+  max-width: 760px;
+  width: 100%;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.title {
+  font-family: var(--font-gloock), serif;
+  font-size: 32px;
+  line-height: 38px;
+  color: var(--album-light);
+}
+
+.empty {
+  font-size: 16px;
+  line-height: 22px;
+  color: var(--album-light);
+  opacity: 0.6;
+}
+
+@media (max-width: 767px) {
+  .page {
+    padding: 0 24px 48px;
+    gap: 16px;
+  }
+}

--- a/src/app/likes/page.tsx
+++ b/src/app/likes/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import Header from "@/components/Header";
+import AlbumPlaylist from "@/components/AlbumPlaylist";
+import { getLikedTracks } from "@/lib/data";
+import { createClient } from "@/lib/supabase/server";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = { title: "My likes — Bohns" };
+
+export default async function LikesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/");
+
+  const tracks = await getLikedTracks(supabase, user.id);
+
+  return (
+    <div className={styles.page}>
+      <Header variant="compact" />
+      <main className={styles.content}>
+        <h1 className={styles.title}>My likes</h1>
+        {tracks.length === 0 ? (
+          <p className={styles.empty}>
+            You haven&apos;t liked any tracks yet. Tap the heart on a track to
+            save it here.
+          </p>
+        ) : (
+          <AlbumPlaylist tracks={tracks} variant="simple" />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/profile/page.module.css
+++ b/src/app/profile/page.module.css
@@ -1,0 +1,85 @@
+.page {
+  max-width: 1440px;
+  margin-inline: auto;
+  padding: 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.content {
+  display: flex;
+  justify-content: center;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 40px;
+  border-radius: var(--radius-card);
+  background: color-mix(in srgb, var(--album-light) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--album-light) 10%, transparent);
+  min-width: 320px;
+  max-width: 420px;
+}
+
+.details {
+  text-align: center;
+}
+
+.name {
+  font-family: var(--font-gloock), serif;
+  font-size: 24px;
+  line-height: 29px;
+  color: var(--album-light);
+}
+
+.email {
+  font-size: 15px;
+  line-height: 20px;
+  color: var(--album-light);
+  opacity: 0.55;
+  margin-top: 4px;
+}
+
+.likesLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--album-accent);
+  transition: color 0.15s ease-out;
+}
+
+.likesLink:hover {
+  color: var(--album-light);
+}
+
+.signout {
+  padding: 10px 20px;
+  border-radius: var(--radius-button);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--album-light);
+  background: color-mix(in srgb, var(--album-accent) 20%, transparent);
+  transition: background 0.15s ease-out;
+}
+
+.signout:hover {
+  background: color-mix(in srgb, var(--album-accent) 35%, transparent);
+}
+
+@media (max-width: 767px) {
+  .page {
+    padding: 0 24px 48px;
+    gap: 16px;
+  }
+
+  .card {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Heart } from "lucide-react";
+import Header from "@/components/Header";
+import UserAvatar from "@/components/UserAvatar";
+import { createClient } from "@/lib/supabase/server";
+import styles from "./page.module.css";
+
+export const metadata: Metadata = { title: "Profile — Bohns" };
+
+export default async function ProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/");
+
+  const meta = user.user_metadata ?? {};
+  const name: string = meta.full_name ?? meta.name ?? user.email ?? "You";
+
+  return (
+    <div className={styles.page}>
+      <Header variant="compact" />
+      <main className={styles.content}>
+        <section className={styles.card}>
+          <UserAvatar user={user} size={96} />
+          <div className={styles.details}>
+            <p className={styles.name}>{name}</p>
+            {user.email && <p className={styles.email}>{user.email}</p>}
+          </div>
+
+          <Link href="/likes" className={styles.likesLink}>
+            <Heart size={18} strokeWidth={2} />
+            <span>My likes</span>
+          </Link>
+
+          <form action="/auth/signout" method="post">
+            <button type="submit" className={styles.signout}>
+              Sign out
+            </button>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/AlbumTrack.tsx
+++ b/src/components/AlbumTrack.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { Heart, Mic, Pause, Play } from "lucide-react";
+import { Mic, Pause, Play } from "lucide-react";
 import { toPlayerTrack, usePlayer } from "@/player/PlayerProvider";
 import { formatTime, useDuration } from "@/player/durations";
 import type { Track } from "@/lib/types";
+import LikeButton from "./LikeButton";
 import LyricsSheet from "./LyricsSheet";
 import styles from "./AlbumTrack.module.css";
 
@@ -65,14 +66,7 @@ export default function AlbumTrack({
         <span className={styles.time}>
           {duration !== null ? formatTime(duration) : "–:–"}
         </span>
-        <button
-          type="button"
-          className={styles.iconButton}
-          aria-label="Like (coming soon)"
-          disabled
-        >
-          <Heart size={20} strokeWidth={2} />
-        </button>
+        <LikeButton trackId={track.track_id} likeCount={track.like_count ?? 0} />
         {detailed && (
           <button
             type="button"

--- a/src/components/AuthStatus.module.css
+++ b/src/components/AuthStatus.module.css
@@ -1,0 +1,26 @@
+.wrapper {
+  position: fixed;
+  top: max(16px, env(safe-area-inset-top));
+  right: max(16px, env(safe-area-inset-right));
+  z-index: 50;
+  display: inline-flex;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  color: var(--album-light);
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
+  backdrop-filter: blur(8px);
+  border: 1px solid color-mix(in srgb, var(--album-light) 14%, transparent);
+  transition: transform 0.2s ease-out, background 0.2s ease-out;
+}
+
+.link:hover {
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  transform: translateY(1px);
+}

--- a/src/components/AuthStatus.tsx
+++ b/src/components/AuthStatus.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { UserCircle } from "lucide-react";
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/client";
+import UserAvatar from "./UserAvatar";
+import styles from "./AuthStatus.module.css";
+
+/** Fixed top-right account control: avatar (signed in) or Google sign-in. */
+export default function AuthStatus() {
+  const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user ?? null);
+      setReady(true);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+      setReady(true);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  async function signIn() {
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
+  }
+
+  // Avoid a sign-in/avatar flash before the session resolves.
+  if (!ready) return <span className={styles.wrapper} aria-hidden />;
+
+  return (
+    <div className={styles.wrapper}>
+      {user ? (
+        <Link href="/profile" className={styles.link} aria-label="Your profile">
+          <UserAvatar user={user} size={36} />
+        </Link>
+      ) : (
+        <button
+          type="button"
+          className={styles.link}
+          onClick={signIn}
+          aria-label="Sign in with Google"
+        >
+          <UserCircle size={24} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/LikeButton.module.css
+++ b/src/components/LikeButton.module.css
@@ -1,0 +1,33 @@
+.like {
+  height: 40px;
+  padding: 0 10px;
+  border-radius: var(--radius-button);
+  color: var(--album-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: color 0.15s ease-out, transform 0.1s ease-out, opacity 0.15s ease-out;
+}
+
+.like:hover {
+  color: var(--album-light);
+}
+
+.like:active {
+  transform: scale(0.92);
+}
+
+.like:disabled {
+  cursor: default;
+}
+
+.liked {
+  color: var(--album-light);
+}
+
+.count {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  min-width: 8px;
+}

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { Heart } from "lucide-react";
+import { useLikes } from "./LikesProvider";
+import styles from "./LikeButton.module.css";
+
+type Props = {
+  trackId: string;
+  likeCount: number;
+};
+
+/** Heart toggle + like count with optimistic update and rollback. */
+export default function LikeButton({ trackId, likeCount }: Props) {
+  const { signedIn, isLiked, toggle } = useLikes();
+  const [count, setCount] = useState(likeCount);
+  const [busy, setBusy] = useState(false);
+
+  const liked = isLiked(trackId);
+
+  async function onClick() {
+    if (busy) return;
+
+    // Signed out: let the provider start the sign-in flow, don't touch the count.
+    if (!signedIn) {
+      toggle(trackId);
+      return;
+    }
+
+    setBusy(true);
+    const wasLiked = liked;
+    setCount((c) => (wasLiked ? Math.max(0, c - 1) : c + 1)); // optimistic
+
+    const { ok } = await toggle(trackId);
+    if (!ok) {
+      setCount((c) => (wasLiked ? c + 1 : Math.max(0, c - 1))); // rollback
+    }
+    setBusy(false);
+  }
+
+  return (
+    <button
+      type="button"
+      className={`${styles.like} ${liked ? styles.liked : ""}`}
+      onClick={onClick}
+      disabled={busy}
+      aria-pressed={liked}
+      aria-label={liked ? "Unlike" : "Like"}
+    >
+      <Heart size={20} strokeWidth={2} fill={liked ? "currentColor" : "none"} />
+      {count > 0 && <span className={styles.count}>{count}</span>}
+    </button>
+  );
+}

--- a/src/components/LikesProvider.tsx
+++ b/src/components/LikesProvider.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createClient } from "@/lib/supabase/client";
+
+type ToggleResult = { ok: boolean };
+
+type LikesContextValue = {
+  /** Whether a user session is active (needed to like). */
+  signedIn: boolean;
+  /** True once the initial session/likes fetch has settled. */
+  ready: boolean;
+  isLiked: (trackId: string) => boolean;
+  /** Optimistically flip a like and persist it (RLS-checked). */
+  toggle: (trackId: string) => Promise<ToggleResult>;
+};
+
+const LikesContext = createContext<LikesContextValue | null>(null);
+
+export function useLikes(): LikesContextValue {
+  const ctx = useContext(LikesContext);
+  if (!ctx) throw new Error("useLikes must be used within <LikesProvider>");
+  return ctx;
+}
+
+export function LikesProvider({ children }: { children: React.ReactNode }) {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [liked, setLiked] = useState<Set<string>>(() => new Set());
+  const [ready, setReady] = useState(false);
+  const supabaseRef = useRef(createClient());
+
+  const loadLikes = useCallback(async (uid: string) => {
+    const supabase = supabaseRef.current;
+    const { data, error } = await supabase
+      .from("track_likes")
+      .select("track_id")
+      .eq("user_id", uid);
+    if (error) {
+      console.error("Failed to load likes", error.message);
+      return;
+    }
+    setLiked(
+      new Set(
+        (data ?? []).map((row: { track_id: string }) => row.track_id)
+      )
+    );
+  }, []);
+
+  useEffect(() => {
+    const supabase = supabaseRef.current;
+
+    supabase.auth.getUser().then(async ({ data }) => {
+      const uid = data.user?.id ?? null;
+      setUserId(uid);
+      if (uid) await loadLikes(uid);
+      setReady(true);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      const uid = session?.user?.id ?? null;
+      setUserId(uid);
+      if (uid) {
+        loadLikes(uid);
+      } else {
+        setLiked(new Set());
+      }
+      setReady(true);
+    });
+
+    return () => subscription.unsubscribe();
+  }, [loadLikes]);
+
+  const signIn = useCallback(async () => {
+    const supabase = supabaseRef.current;
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
+  }, []);
+
+  const isLiked = useCallback((trackId: string) => liked.has(trackId), [liked]);
+
+  const toggle = useCallback(
+    async (trackId: string): Promise<ToggleResult> => {
+      if (!userId) {
+        await signIn();
+        return { ok: false };
+      }
+
+      const wasLiked = liked.has(trackId);
+
+      // Optimistic set update.
+      setLiked((prev) => {
+        const next = new Set(prev);
+        if (wasLiked) next.delete(trackId);
+        else next.add(trackId);
+        return next;
+      });
+
+      const supabase = supabaseRef.current;
+      const { error } = wasLiked
+        ? await supabase
+            .from("track_likes")
+            .delete()
+            .eq("user_id", userId)
+            .eq("track_id", trackId)
+        : await supabase
+            .from("track_likes")
+            .upsert(
+              { user_id: userId, track_id: trackId },
+              { onConflict: "user_id,track_id" }
+            );
+
+      if (error) {
+        // Roll back the optimistic change.
+        setLiked((prev) => {
+          const next = new Set(prev);
+          if (wasLiked) next.add(trackId);
+          else next.delete(trackId);
+          return next;
+        });
+        console.error("Failed to toggle like", error.message);
+        return { ok: false };
+      }
+
+      return { ok: true };
+    },
+    [userId, liked, signIn]
+  );
+
+  const value = useMemo<LikesContextValue>(
+    () => ({ signedIn: Boolean(userId), ready, isLiked, toggle }),
+    [userId, ready, isLiked, toggle]
+  );
+
+  return <LikesContext.Provider value={value}>{children}</LikesContext.Provider>;
+}

--- a/src/components/UserAvatar.module.css
+++ b/src/components/UserAvatar.module.css
@@ -1,0 +1,27 @@
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--size, 36px);
+  height: var(--size, 36px);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--album-light) 25%, transparent);
+  background: color-mix(in srgb, var(--album-light) 12%, transparent);
+  color: var(--album-light);
+  font-family: var(--font-grotesk), sans-serif;
+  font-size: calc(var(--size, 36px) * 0.45);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.avatar img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.fallback {
+  line-height: 1;
+}

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable @next/next/no-img-element */
+import type { User } from "@supabase/supabase-js";
+import styles from "./UserAvatar.module.css";
+
+type Props = {
+  user: User;
+  size?: number;
+  className?: string;
+};
+
+function displayName(user: User): string {
+  const meta = user.user_metadata ?? {};
+  return meta.full_name ?? meta.name ?? user.email ?? "Anonymous";
+}
+
+/** Round avatar from the user's Google picture, or their first initial. */
+export default function UserAvatar({ user, size = 36, className = "" }: Props) {
+  const meta = user.user_metadata ?? {};
+  const avatarUrl: string | null = meta.avatar_url ?? meta.picture ?? null;
+  const name = displayName(user);
+  const fallback = name.trim() ? name.trim().charAt(0).toUpperCase() : "?";
+
+  return (
+    <span
+      className={`${styles.avatar} ${className}`}
+      style={{ ["--size" as string]: `${size}px` }}
+      aria-label={name}
+      role="img"
+    >
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={name}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <span className={styles.fallback}>{fallback}</span>
+      )}
+    </span>
+  );
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,5 @@
-import { supabase } from "./supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { supabase } from "./supabase/anon";
 import type { Album, AlbumWithTracks, Track, TrackLyrics } from "./types";
 
 const ALBUM_COLS = "id,name,description,type,cover_url,created_at";
@@ -77,4 +78,37 @@ export async function getLyrics(trackIds: string[]): Promise<TrackLyrics> {
   return Object.fromEntries(
     (data ?? []).map((row) => [row.id as string, row.lyrics as string | null])
   );
+}
+
+/**
+ * Tracks the given user has liked, most recently liked first.
+ * Requires an authenticated client (RLS restricts track_likes to the owner).
+ */
+export async function getLikedTracks(
+  client: SupabaseClient,
+  userId: string
+): Promise<Track[]> {
+  const { data: likes, error: likesErr } = await client
+    .from("track_likes")
+    .select("track_id")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  if (likesErr) fail("Failed to load likes", likesErr);
+
+  const likedIds = (likes ?? []).map((row) => row.track_id as string);
+  if (likedIds.length === 0) return [];
+
+  const { data: tracks, error: tracksErr } = await client
+    .from("track_overview")
+    .select(TRACK_COLS)
+    .in("track_id", likedIds);
+  if (tracksErr) fail("Failed to load liked tracks", tracksErr);
+
+  // Preserve the like-recency order from the track_likes query.
+  const byId = new Map(
+    ((tracks ?? []) as Track[]).map((track) => [track.track_id, track])
+  );
+  return likedIds
+    .map((id) => byId.get(id))
+    .filter((track): track is Track => Boolean(track));
 }

--- a/src/lib/supabase/anon.ts
+++ b/src/lib/supabase/anon.ts
@@ -18,7 +18,8 @@ try {
   );
 }
 
-/** Anonymous read-only client — no auth in step 1, server-side usage only. */
+/** Anonymous read-only client for public content (albums, tracks, lyrics).
+ *  Not tied to a user session — auth flows use the browser/server clients. */
 export const supabase = createClient(url, anonKey, {
   auth: { persistSession: false },
 });

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,19 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+let browserClient: SupabaseClient | undefined;
+
+/**
+ * Browser Supabase client (cookie-backed session via @supabase/ssr).
+ * Used by client components for auth state and RLS-checked like writes.
+ * Memoized so all client components share one GoTrue instance.
+ */
+export function createClient(): SupabaseClient {
+  if (!browserClient) {
+    browserClient = createBrowserClient(url, anonKey);
+  }
+  return browserClient;
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+/**
+ * Server Supabase client bound to the request cookies (@supabase/ssr).
+ * Used by route handlers (OAuth callback / signout) and the protected
+ * server components (/profile, /likes) that need the current user.
+ */
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          );
+        } catch {
+          // `setAll` from a Server Component — cookies are read-only there.
+          // The middleware refreshes the session, so this is safe to ignore.
+        }
+      },
+    },
+  });
+}

--- a/supabase/migrations/20260710_track_likes.sql
+++ b/supabase/migrations/20260710_track_likes.sql
@@ -1,0 +1,40 @@
+-- Migration: create track_likes table for authenticated per-user likes.
+--
+-- The like aggregate surfaced by the `track_overview` view (like_count) counts
+-- rows in this table. This migration is written to be idempotent so it can run
+-- safely against a project where the table/policies already exist (created via
+-- the Supabase dashboard in the app's previous incarnation).
+
+create table if not exists public.track_likes (
+    user_id    uuid not null references auth.users(id) on delete cascade,
+    track_id   uuid not null references public.tracks(id) on delete cascade,
+    created_at timestamptz not null default now(),
+
+    primary key (user_id, track_id)
+);
+
+-- Query the most-recently-liked tracks per user (used by the /likes page).
+create index if not exists track_likes_user_created_idx
+    on public.track_likes (user_id, created_at desc);
+
+-- Aggregate like counts per track (used by the track_overview view).
+create index if not exists track_likes_track_id_idx
+    on public.track_likes (track_id);
+
+-- Row-level security: a user may only see and change their own likes.
+alter table public.track_likes enable row level security;
+
+drop policy if exists "Users can read their own likes" on public.track_likes;
+create policy "Users can read their own likes"
+    on public.track_likes for select
+    using (auth.uid() = user_id);
+
+drop policy if exists "Users can insert their own likes" on public.track_likes;
+create policy "Users can insert their own likes"
+    on public.track_likes for insert
+    with check (auth.uid() = user_id);
+
+drop policy if exists "Users can delete their own likes" on public.track_likes;
+create policy "Users can delete their own likes"
+    on public.track_likes for delete
+    using (auth.uid() = user_id);


### PR DESCRIPTION
Both features existed in the previous SvelteKit app and were dropped by the
Next.js migration. This ports them to the App Router.

Auth (Google OAuth via @supabase/ssr):
- split Supabase clients into src/lib/supabase/{anon,client,server}.ts
- middleware.ts refreshes the session cookie on every request
- /auth/callback exchanges the OAuth code; /auth/signout clears the session
- AuthStatus (fixed top-right) + UserAvatar handle sign-in / avatar

Likes (RLS-enforced, client-side so the public catalog stays ISR):
- track_likes migration (idempotent) mirroring the track_plays RLS pattern
- LikesProvider loads the user's liked ids and toggles rows via the browser
  client with optimistic update + rollback
- LikeButton replaces the disabled placeholder in AlbumTrack (heart + count)

Pages:
- /profile shows the signed-in user + sign-out
- /likes lists the user's liked tracks, most recent first

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014FyvKcsn6D2eyFst29ppYh