### PR TITLE
Artist content management: model + RPCs + storage + inline edit UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Brainstorming visual-companion mockups
+.superpowers/

--- a/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
+++ b/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
@@ -1,0 +1,1197 @@
+# Artist Content API Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the database foundation for artist content management — a roles layer, genre vocabulary, setlist ordering, and a full set of `SECURITY DEFINER` RPCs that let a member CRUD albums, tracks, and versions (and their Storage files) in single authorized calls.
+
+**Architecture:** All writes go through Postgres `SECURITY DEFINER` functions that check `artist_members` membership *before* touching data; the content tables keep RLS on with public read and **no** client write policies, so the RPCs are the only write path. Files upload directly to Storage from the client (authorized by Storage RLS on the same membership); the client passes the SDK-derived public URL back to a finalize RPC. No service-role key is used anywhere.
+
+**Tech Stack:** Supabase Postgres (RLS, PL/pgSQL, enums, generated columns), Supabase Storage, Supabase CLI v2.84.2. This plan is the backend/API layer only — the inline edit UI is Plan 2.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-artist-content-management-design.md`
+
+---
+
+## Conventions for every task
+
+**Applying a migration.** Migration files live in `supabase/migrations/`. Apply each by either:
+- pasting its contents into the Supabase **dashboard SQL editor** and running it, or
+- `supabase link --project-ref <your-ref>` (once) then `supabase db push`.
+
+There is **no dev project** — migrations apply to prod. Every migration in this plan is **additive** (new tables, columns, functions, policies) and touches no existing rows except explicit, reviewed backfills. Review each migration before applying.
+
+**Verifying a task (no test framework).** Each task ships a verification block that is a single self-contained PL/pgSQL `DO` block wrapped in `begin; … rollback;`. Run it in the Supabase SQL editor. The pattern:
+
+- The `DO` block declares its own variables, seeds throwaway fixtures, and asserts — everything server-side, so there are no psql `\gset` / `:var` gymnastics (psql does **not** interpolate variables inside dollar-quoted blocks).
+- It picks a real user to impersonate with `select id into _uid from auth.users limit 1;` (nothing to paste), and switches identity by setting the JWT claim: `perform set_config('request.jwt.claims', json_build_object('sub', _uid, 'role','authenticated')::text, true);`. The RPCs read `auth.uid()` from that claim; because they are `SECURITY DEFINER` they bypass table RLS, so no `SET ROLE` is needed to exercise their authorization logic.
+- Assertions use PL/pgSQL `assert <cond>, '<msg>'` — a failure aborts the block loudly. Negative ("should be rejected") checks wrap the call in `begin … exception when insufficient_privilege then null; end;`.
+- The surrounding `begin; … rollback;` discards every fixture, so **nothing persists to prod**. A passing block prints `NOTICE: Task N verification passed`.
+
+**"Expected to fail first."** Before applying a task's migration, run its verification block — it must fail (missing table/function). That is the red state. Apply the migration, re-run, it goes green. Then commit.
+
+**Commit style.** One commit per task: `git add supabase/migrations/<file> && git commit -m "<msg>"`.
+
+---
+
+## Task 1: Roles foundation — `artist_members` + `is_artist_member` guard
+
+**Files:**
+- Create: `supabase/migrations/20260712000100_artist_members.sql`
+
+- [ ] **Step 1: Write the verification block** (save nowhere — run it in the SQL editor; expect failure now)
+
+```sql
+begin;
+do $$
+declare _uid uuid; _artist uuid;
+begin
+  select id into _uid from auth.users limit 1;
+  assert _uid is not null, 'need at least one auth user to impersonate';
+  insert into public.artists (name) values ('Verify Artist') returning id into _artist;
+  insert into public.artist_members (artist_id, user_id, role) values (_artist, _uid, 'owner');
+
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+
+  assert public.is_artist_member(_artist), 'seeded owner should be a member';
+  assert not public.is_artist_member(gen_random_uuid()), 'random artist id should not be a member';
+  raise notice 'Task 1 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Expected: `ERROR: relation "public.artist_members" does not exist` (or missing function). This is the red state.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000100_artist_members.sql
+-- Roles layer: which users may manage which artist, plus the membership guard
+-- every content RPC calls first.
+
+create table if not exists public.artist_members (
+  artist_id  uuid not null references public.artists(id) on delete cascade,
+  user_id    uuid not null references auth.users(id)     on delete cascade,
+  role       text not null check (role in ('owner','maintainer')),
+  created_at timestamptz not null default now(),
+  primary key (artist_id, user_id)
+);
+
+alter table public.artist_members enable row level security;
+
+-- A member may read the membership rows of artists they belong to. No client
+-- writes: memberships are seeded manually in the dashboard for now.
+drop policy if exists "members read own artist memberships" on public.artist_members;
+create policy "members read own artist memberships"
+  on public.artist_members for select
+  using (
+    exists (
+      select 1 from public.artist_members m
+      where m.artist_id = artist_members.artist_id
+        and m.user_id = auth.uid()
+    )
+  );
+
+-- SECURITY DEFINER so it can read artist_members regardless of the caller's RLS.
+create or replace function public.is_artist_member(_artist_id uuid)
+  returns boolean
+  language sql
+  security definer
+  set search_path = public, pg_temp
+  stable
+as $$
+  select exists (
+    select 1 from public.artist_members m
+    where m.artist_id = _artist_id
+      and m.user_id = auth.uid()
+  );
+$$;
+
+revoke all on function public.is_artist_member(uuid) from public;
+grant execute on function public.is_artist_member(uuid) to anon, authenticated;
+```
+
+- [ ] **Step 4: Apply the migration** (dashboard SQL editor or `supabase db push`).
+
+- [ ] **Step 5: Re-run the verification block — expect success**
+
+Expected: no assertion errors; the `do` block completes silently, then `ROLLBACK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000100_artist_members.sql
+git commit -m "feat(db): add artist_members roles table and is_artist_member guard"
+```
+
+---
+
+## Task 2: Genre vocabulary — `genres` + `album_genres` + `slugify`
+
+**Files:**
+- Create: `supabase/migrations/20260712000200_genres.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure)
+
+```sql
+begin;
+do $$
+declare _slug text;
+begin
+  insert into public.genres (name) values ('Synth Wave');
+  select slug into _slug from public.genres where name = 'Synth Wave';
+  assert _slug = 'synth-wave', 'slug should be a full slugified name (got: ' || coalesce(_slug,'<null>') || ')';
+  raise notice 'Task 2 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Expected: `ERROR: relation "public.genres" does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000200_genres.sql
+-- Controlled genre vocabulary (searchable combobox source) + album links.
+
+-- Full slug helper (genres appear in URLs/filters, not storage paths, so unlike
+-- track/artist 3-char slugs this is a real slug).
+create or replace function public.slugify(_text text)
+  returns text language sql immutable as $$
+  select trim(both '-' from regexp_replace(lower(coalesce(_text,'')), '[^a-z0-9]+', '-', 'g'));
+$$;
+
+create table if not exists public.genres (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null unique,
+  slug       text not null default '',
+  created_at timestamptz not null default now()
+);
+
+-- Keep slug in sync with name via trigger (a plain default can't reference name
+-- reliably across updates).
+create or replace function public.genres_set_slug()
+  returns trigger language plpgsql as $$
+begin
+  new.slug := public.slugify(new.name);
+  return new;
+end $$;
+
+drop trigger if exists genres_slug on public.genres;
+create trigger genres_slug before insert or update of name on public.genres
+  for each row execute function public.genres_set_slug();
+
+create table if not exists public.album_genres (
+  album_id uuid not null references public.albums(id) on delete cascade,
+  genre_id uuid not null references public.genres(id) on delete cascade,
+  primary key (album_id, genre_id)
+);
+
+alter table public.genres       enable row level security;
+alter table public.album_genres enable row level security;
+
+drop policy if exists "public read genres" on public.genres;
+create policy "public read genres" on public.genres for select using (true);
+
+drop policy if exists "public read album_genres" on public.album_genres;
+create policy "public read album_genres" on public.album_genres for select using (true);
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (asserts pass; `synth-wave` slug produced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000200_genres.sql
+git commit -m "feat(db): add genres and album_genres with slugify"
+```
+
+---
+
+## Task 3: Link albums to artists — `albums.artist_id` + backfill
+
+**Files:**
+- Create: `supabase/migrations/20260712000300_albums_artist_id.sql`
+
+**Precondition:** exactly one artist exists today (`bohns`). Confirm with `select id, name from public.artists;` and adjust the backfill's `name` filter if yours differs.
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure — column missing)
+
+```sql
+do $$ begin
+  assert (select count(*) from public.albums where artist_id is null) = 0,
+    'every album should have an artist_id after backfill';
+  assert (select count(distinct artist_id) from public.albums) >= 1,
+    'albums point at a real artist';
+end $$;
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Expected: `ERROR: column "artist_id" does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000300_albums_artist_id.sql
+-- Associate every album with an artist. Backfill existing albums to bohns.
+
+alter table public.albums
+  add column if not exists artist_id uuid references public.artists(id);
+
+update public.albums
+  set artist_id = (select id from public.artists where name = 'bohns' limit 1)
+  where artist_id is null;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (no null `artist_id`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000300_albums_artist_id.sql
+git commit -m "feat(db): add albums.artist_id and backfill to bohns"
+```
+
+---
+
+## Task 4: Setlist ordering — `album_tracks.position` + backfill
+
+**Files:**
+- Create: `supabase/migrations/20260712000400_album_tracks_position.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure — column missing)
+
+```sql
+-- For each album, positions must be 1..N with no gaps or dupes.
+do $$
+declare bad int;
+begin
+  select count(*) into bad from (
+    select album_id,
+           count(*)                          as n,
+           min(position)                      as lo,
+           max(position)                      as hi,
+           count(distinct position)           as distinct_n
+    from public.album_tracks
+    where album_id is not null
+    group by album_id
+    having min(position) <> 1
+        or max(position) <> count(*)
+        or count(distinct position) <> count(*)
+  ) t;
+  assert bad = 0, 'each album should have contiguous 1..N positions';
+end $$;
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Expected: `ERROR: column "position" does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000400_album_tracks_position.sql
+-- Explicit setlist order within an album. Backfill from insertion order.
+
+alter table public.album_tracks
+  add column if not exists position int;
+
+with ordered as (
+  select id,
+         row_number() over (partition by album_id order by created_at, id) as rn
+  from public.album_tracks
+)
+update public.album_tracks at
+  set position = ordered.rn
+  from ordered
+  where ordered.id = at.id
+    and at.position is null;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (contiguous positions per album).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000400_album_tracks_position.sql
+git commit -m "feat(db): add album_tracks.position for setlist order + backfill"
+```
+
+---
+
+## Task 5: Write lockdown — public read stays, no client writes
+
+RLS is already enabled on the content tables and they are publicly readable. This task **guarantees** the lockdown invariant: the only content-table SELECT policies are public, and there are **no** INSERT/UPDATE/DELETE policies for `anon`/`authenticated` (so the `SECURITY DEFINER` RPCs are the sole write path).
+
+**Files:**
+- Create: `supabase/migrations/20260712000500_content_read_policies.sql`
+
+- [ ] **Step 1: Write the verification block** (run now — the anon-read asserts may already pass; the "no write policy" assert is the meaningful one and should hold after the migration)
+
+```sql
+-- 1) No write policies for client roles on content tables.
+do $$
+declare bad int;
+begin
+  select count(*) into bad
+  from pg_policies
+  where schemaname = 'public'
+    and tablename in ('albums','tracks','versions','album_tracks','track_versions','album_genres')
+    and cmd in ('INSERT','UPDATE','DELETE');
+  assert bad = 0, 'content tables must have no client INSERT/UPDATE/DELETE policies (found ' || bad || ')';
+  raise notice 'no client write policies: ok';
+end $$;
+
+-- 2) A direct client-role INSERT must be blocked by RLS. Run this separately;
+--    the EXPECTED result is an ERROR (new row violates row-level security policy).
+begin;
+  set local role authenticated;
+  insert into public.albums (name, type) values ('should-fail', 'album');
+  reset role;
+rollback;
+```
+
+- [ ] **Step 2: Run it — note current state**
+
+If the "no write policies" assert fails, an unexpected write policy exists — inspect with `select * from pg_policies where tablename='albums';` and fold a matching `drop policy` into Step 3.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000500_content_read_policies.sql
+-- Ensure public read on artists + content, and (idempotently) that RLS is on.
+-- Writes are intentionally NOT granted to client roles; SECURITY DEFINER RPCs
+-- (Tasks 6-9) are the only write path.
+
+alter table public.artists      enable row level security;
+alter table public.albums       enable row level security;
+alter table public.tracks       enable row level security;
+alter table public.versions     enable row level security;
+alter table public.album_tracks enable row level security;
+alter table public.track_versions enable row level security;
+
+drop policy if exists "public read artists" on public.artists;
+create policy "public read artists" on public.artists for select using (true);
+
+drop policy if exists "public read albums" on public.albums;
+create policy "public read albums" on public.albums for select using (true);
+
+drop policy if exists "public read tracks" on public.tracks;
+create policy "public read tracks" on public.tracks for select using (true);
+
+drop policy if exists "public read versions" on public.versions;
+create policy "public read versions" on public.versions for select using (true);
+
+drop policy if exists "public read album_tracks" on public.album_tracks;
+create policy "public read album_tracks" on public.album_tracks for select using (true);
+
+drop policy if exists "public read track_versions" on public.track_versions;
+create policy "public read track_versions" on public.track_versions for select using (true);
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (both asserts pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000500_content_read_policies.sql
+git commit -m "feat(db): lock content writes to RPCs, ensure public read policies"
+```
+
+---
+
+## Task 6: Album RPCs — create / update / delete / genres / cover
+
+**Files:**
+- Create: `supabase/migrations/20260712000600_rpc_albums.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure — functions missing)
+
+```sql
+begin;
+do $$
+declare
+  _uid uuid; _outsider uuid := gen_random_uuid();
+  _artist uuid; _gid uuid; _album uuid;
+begin
+  select id into _uid from auth.users limit 1;
+  assert _uid is not null, 'need an auth user to impersonate';
+  insert into public.artists (name) values ('RPC Album Artist') returning id into _artist;
+  insert into public.artist_members (artist_id, user_id, role) values (_artist, _uid, 'owner');
+  insert into public.genres (name) values ('Verify Genre ' || _artist) returning id into _gid;
+
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+
+  -- create with a genre
+  _album := (public.create_album(_artist, 'My Album', 'album', 'desc', array[_gid])).id;
+  assert (select artist_id from public.albums where id = _album) = _artist, 'album belongs to the artist';
+  assert exists (select 1 from public.album_genres where album_id = _album and genre_id = _gid), 'genre linked on create';
+
+  -- update
+  perform public.update_album(_album, 'Renamed', 'new desc', 'ep');
+  assert (select name from public.albums where id = _album) = 'Renamed', 'name updated';
+  assert (select type::text from public.albums where id = _album) = 'ep', 'type updated';
+
+  -- cover + genres setters
+  perform public.set_album_cover(_album, 'https://example.test/cover.jpg');
+  assert (select cover_url from public.albums where id = _album) = 'https://example.test/cover.jpg', 'cover set';
+  perform public.set_album_genres(_album, '{}'::uuid[]);
+  assert not exists (select 1 from public.album_genres where album_id = _album), 'genres replaced with empty';
+
+  -- non-member is rejected
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _outsider, 'role','authenticated')::text, true);
+  begin
+    perform public.update_album(_album, 'Hacked', 'x', 'single');
+    assert false, 'non-member update should have raised';
+  exception when insufficient_privilege then null;
+  end;
+
+  raise notice 'Task 6 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+Expected: `ERROR: function public.create_album(...) does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000600_rpc_albums.sql
+-- Album CRUD. Every function checks membership first and raises
+-- insufficient_privilege (42501) for non-members. Album type enum is
+-- public.album_type (values: single | ep | album).
+
+-- Guard: caller is a member of the album's artist.
+create or replace function public.is_member_of_album(_album_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select public.is_artist_member((select artist_id from public.albums where id = _album_id));
+$$;
+
+create or replace function public.create_album(
+  _artist_id   uuid,
+  _name        text,
+  _type        public.album_type,
+  _description text default null,
+  _genre_ids   uuid[] default '{}'
+) returns public.albums
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _album public.albums;
+begin
+  if not public.is_artist_member(_artist_id) then
+    raise exception 'not a member of artist %', _artist_id using errcode = '42501';
+  end if;
+  insert into public.albums (artist_id, name, type, description)
+    values (_artist_id, _name, _type, _description)
+    returning * into _album;
+  if array_length(_genre_ids, 1) is not null then
+    insert into public.album_genres (album_id, genre_id)
+      select _album.id, g from unnest(_genre_ids) g
+      on conflict do nothing;
+  end if;
+  return _album;
+end $$;
+
+create or replace function public.update_album(
+  _album_id    uuid,
+  _name        text,
+  _description text,
+  _type        public.album_type
+) returns public.albums
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _album public.albums;
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.albums
+    set name = _name, description = _description, type = _type
+    where id = _album_id
+    returning * into _album;
+  return _album;
+end $$;
+
+create or replace function public.delete_album(_album_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.albums where id = _album_id;
+end $$;
+
+create or replace function public.set_album_genres(_album_id uuid, _genre_ids uuid[])
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.album_genres where album_id = _album_id;
+  if array_length(_genre_ids, 1) is not null then
+    insert into public.album_genres (album_id, genre_id)
+      select _album_id, g from unnest(_genre_ids) g
+      on conflict do nothing;
+  end if;
+end $$;
+
+-- Client uploads the cover to Storage, then passes the SDK getPublicUrl() result
+-- here (machine-written, never hand-typed).
+create or replace function public.set_album_cover(_album_id uuid, _cover_url text)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.albums set cover_url = _cover_url where id = _album_id;
+end $$;
+
+revoke all on function
+  public.create_album(uuid,text,public.album_type,text,uuid[]),
+  public.update_album(uuid,text,text,public.album_type),
+  public.delete_album(uuid),
+  public.set_album_genres(uuid,uuid[]),
+  public.set_album_cover(uuid,text)
+  from public;
+grant execute on function
+  public.create_album(uuid,text,public.album_type,text,uuid[]),
+  public.update_album(uuid,text,text,public.album_type),
+  public.delete_album(uuid),
+  public.set_album_genres(uuid,uuid[]),
+  public.set_album_cover(uuid,text)
+  to authenticated;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (member path asserts pass; non-member raises `insufficient_privilege`, caught).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000600_rpc_albums.sql
+git commit -m "feat(db): album CRUD RPCs (create/update/delete/genres/cover)"
+```
+
+---
+
+## Task 7: Track RPCs — create / update / remove / delete / reorder setlist
+
+**Files:**
+- Create: `supabase/migrations/20260712000700_rpc_tracks.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure)
+
+```sql
+begin;
+do $$
+declare
+  _uid uuid; _outsider uuid := gen_random_uuid();
+  _artist uuid; _album uuid; _t1 uuid; _t2 uuid;
+begin
+  select id into _uid from auth.users limit 1;
+  assert _uid is not null, 'need an auth user to impersonate';
+  insert into public.artists (name) values ('RPC Track Artist') returning id into _artist;
+  insert into public.artist_members (artist_id, user_id, role) values (_artist, _uid, 'owner');
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+
+  _album := (public.create_album(_artist, 'Setlist Album', 'album', null, '{}')).id;
+  _t1 := (public.create_track(_album, 'Track One', null, null)).id;
+  _t2 := (public.create_track(_album, 'Track Two', null, null)).id;
+  assert (select position from public.album_tracks where album_id=_album and track_id=_t1) = 1, 't1 at position 1';
+  assert (select position from public.album_tracks where album_id=_album and track_id=_t2) = 2, 't2 at position 2';
+
+  -- reorder: t2 before t1
+  perform public.reorder_setlist(_album, array[_t2, _t1]);
+  assert (select position from public.album_tracks where album_id=_album and track_id=_t2) = 1, 't2 now first';
+  assert (select position from public.album_tracks where album_id=_album and track_id=_t1) = 2, 't1 now second';
+
+  -- remove t1 from album (track row survives, link gone)
+  perform public.remove_track_from_album(_album, _t1);
+  assert not exists (select 1 from public.album_tracks where album_id=_album and track_id=_t1), 'link removed';
+  assert exists (select 1 from public.tracks where id=_t1), 'track row survives';
+
+  -- delete t2 entirely
+  perform public.delete_track(_t2);
+  assert not exists (select 1 from public.tracks where id=_t2), 'track deleted';
+
+  -- non-member rejected
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _outsider, 'role','authenticated')::text, true);
+  begin
+    perform public.create_track(_album, 'Hack', null, null);
+    assert false, 'non-member create_track should raise';
+  exception when insufficient_privilege then null;
+  end;
+
+  raise notice 'Task 7 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure** (`function public.create_track(...) does not exist`).
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000700_rpc_tracks.sql
+-- Track CRUD + setlist ordering. create_track inserts the track AND the
+-- album_tracks link at the next position in one call.
+
+-- Guard: caller is a member of any artist that owns an album this track is on.
+create or replace function public.is_member_of_track(_track_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (
+    select 1
+    from public.album_tracks at
+    join public.albums a on a.id = at.album_id
+    where at.track_id = _track_id
+      and public.is_artist_member(a.artist_id)
+  );
+$$;
+
+create or replace function public.create_track(
+  _album_id    uuid,
+  _name        text,
+  _description text default null,
+  _lyrics      text default null
+) returns public.tracks
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _track public.tracks; _next int;
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  insert into public.tracks (name, description, lyrics)
+    values (_name, _description, _lyrics)
+    returning * into _track;
+  select coalesce(max(position), 0) + 1 into _next
+    from public.album_tracks where album_id = _album_id;
+  insert into public.album_tracks (album_id, track_id, position)
+    values (_album_id, _track.id, _next);
+  return _track;
+end $$;
+
+create or replace function public.update_track(
+  _track_id uuid, _name text, _description text, _lyrics text
+) returns public.tracks
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _track public.tracks;
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  update public.tracks set name=_name, description=_description, lyrics=_lyrics
+    where id=_track_id returning * into _track;
+  return _track;
+end $$;
+
+-- Unlink a track from one album (renumber remaining positions), keep the track row.
+create or replace function public.remove_track_from_album(_album_id uuid, _track_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.album_tracks where album_id=_album_id and track_id=_track_id;
+  with ordered as (
+    select id, row_number() over (order by position, id) as rn
+    from public.album_tracks where album_id=_album_id
+  )
+  update public.album_tracks at set position = ordered.rn
+    from ordered where ordered.id = at.id;
+end $$;
+
+-- Delete a track everywhere: its album links, its version links, and its
+-- now-orphaned versions. (Version files are cleaned up client-side.)
+create or replace function public.delete_track(_track_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  delete from public.versions v
+    using public.track_versions tv
+    where tv.version_id = v.id and tv.track_id = _track_id;
+  delete from public.track_versions where track_id = _track_id;
+  delete from public.album_tracks where track_id = _track_id;
+  delete from public.tracks where id = _track_id;
+end $$;
+
+-- Reorder a whole album's setlist from an ordered array of track ids.
+create or replace function public.reorder_setlist(_album_id uuid, _ordered_track_ids uuid[])
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.album_tracks at
+    set position = ord.rn
+    from (select id, ordinality::int as rn
+          from unnest(_ordered_track_ids) with ordinality as u(id, ordinality)) ord
+    where at.album_id = _album_id and at.track_id = ord.id;
+end $$;
+
+revoke all on function
+  public.create_track(uuid,text,text,text),
+  public.update_track(uuid,text,text,text),
+  public.remove_track_from_album(uuid,uuid),
+  public.delete_track(uuid),
+  public.reorder_setlist(uuid,uuid[])
+  from public;
+grant execute on function
+  public.create_track(uuid,text,text,text),
+  public.update_track(uuid,text,text,text),
+  public.remove_track_from_album(uuid,uuid),
+  public.delete_track(uuid),
+  public.reorder_setlist(uuid,uuid[])
+  to authenticated;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000700_rpc_tracks.sql
+git commit -m "feat(db): track CRUD + reorder_setlist RPCs"
+```
+
+---
+
+## Task 8: Version RPCs — create (returns upload path) / finalize / update / delete
+
+The `create_version` function returns the new id **and** the deterministic storage
+path `{track.slug}-{track.id}/{track.slug}-{version.id}.m4a` (the file reuses the
+track's slug; versions have no slug of their own). The client uploads to that path,
+then calls `set_version_file` with the SDK-derived public URL.
+
+**Files:**
+- Create: `supabase/migrations/20260712000800_rpc_versions.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure)
+
+```sql
+begin;
+do $$
+declare
+  _uid uuid; _outsider uuid := gen_random_uuid();
+  _artist uuid; _album uuid; _tid uuid; _slug text;
+  _vid uuid; _path text; _expected text;
+begin
+  select id into _uid from auth.users limit 1;
+  assert _uid is not null, 'need an auth user to impersonate';
+  insert into public.artists (name) values ('RPC Version Artist') returning id into _artist;
+  insert into public.artist_members (artist_id, user_id, role) values (_artist, _uid, 'owner');
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+
+  _album := (public.create_album(_artist, 'V Album', 'album', null, '{}')).id;
+  _tid := (public.create_track(_album, 'Night Drive', null, null)).id;
+  select slug into _slug from public.tracks where id = _tid;
+
+  select version_id, upload_path into _vid, _path
+    from public.create_version(_tid, 'First Mix', 'demo', current_date);
+  _expected := _slug || '-' || _tid || '/' || _slug || '-' || _vid || '.m4a';
+
+  assert exists (select 1 from public.versions where id = _vid), 'version row created';
+  assert exists (select 1 from public.track_versions where track_id=_tid and version_id=_vid), 'link created';
+  assert (select track_id from public.versions where id=_vid) = _tid, 'versions.track_id kept in sync';
+  assert _path = _expected, 'upload_path follows {track.slug}-{track.id}/{track.slug}-{version.id}.m4a (got ' || _path || ')';
+
+  perform public.set_version_file(_vid, 'https://example.test/songs/x.m4a');
+  assert (select resource_url from public.versions where id=_vid) = 'https://example.test/songs/x.m4a', 'resource_url written';
+
+  perform public.update_version(_vid, 'First Mix', 'final', current_date);
+  assert (select status::text from public.versions where id=_vid) = 'final', 'status updated';
+
+  perform public.delete_version(_vid);
+  assert not exists (select 1 from public.versions where id=_vid), 'version deleted';
+  assert not exists (select 1 from public.track_versions where version_id=_vid), 'link deleted';
+
+  -- non-member rejected
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _outsider, 'role','authenticated')::text, true);
+  begin
+    perform public.create_version(_tid, 'Hack', 'raw', current_date);
+    assert false, 'non-member create_version should raise';
+  exception when insufficient_privilege then null;
+  end;
+
+  raise notice 'Task 8 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure** (`function public.create_version(...) does not exist`).
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000800_rpc_versions.sql
+-- Version CRUD. create_version inserts the version + track_versions link and
+-- returns the deterministic Storage upload path. set_version_file stores the
+-- client's SDK-derived public URL. versions.track_id kept in sync (junction stays
+-- canonical).
+
+create or replace function public.is_member_of_version(_version_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (
+    select 1 from public.track_versions tv
+    where tv.version_id = _version_id
+      and public.is_member_of_track(tv.track_id)
+  );
+$$;
+
+create or replace function public.create_version(
+  _track_id     uuid,
+  _name         text,
+  _status       public.version_status,
+  _release_date date default current_date
+) returns table (version_id uuid, upload_path text)
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _vid uuid; _slug text; _tid uuid := _track_id;
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  select slug into _slug from public.tracks where id = _track_id;
+  insert into public.versions (name, status, release_date, track_id)
+    values (_name, _status, _release_date, _track_id)
+    returning id into _vid;
+  insert into public.track_versions (track_id, version_id) values (_track_id, _vid);
+  version_id  := _vid;
+  upload_path := _slug || '-' || _tid || '/' || _slug || '-' || _vid || '.m4a';
+  return next;
+end $$;
+
+-- Client uploads to upload_path, then passes getPublicUrl(path).data.publicUrl here.
+create or replace function public.set_version_file(_version_id uuid, _resource_url text)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  update public.versions set resource_url = _resource_url where id = _version_id;
+end $$;
+
+create or replace function public.update_version(
+  _version_id uuid, _name text, _status public.version_status, _release_date date
+) returns public.versions
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _v public.versions;
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  update public.versions set name=_name, status=_status, release_date=_release_date
+    where id=_version_id returning * into _v;
+  return _v;
+end $$;
+
+create or replace function public.delete_version(_version_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  delete from public.track_versions where version_id = _version_id;
+  delete from public.versions where id = _version_id;
+end $$;
+
+revoke all on function
+  public.create_version(uuid,text,public.version_status,date),
+  public.set_version_file(uuid,text),
+  public.update_version(uuid,text,public.version_status,date),
+  public.delete_version(uuid)
+  from public;
+grant execute on function
+  public.create_version(uuid,text,public.version_status,date),
+  public.set_version_file(uuid,text),
+  public.update_version(uuid,text,public.version_status,date),
+  public.delete_version(uuid)
+  to authenticated;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (path format asserts pass; non-member rejected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000800_rpc_versions.sql
+git commit -m "feat(db): version RPCs with deterministic upload path"
+```
+
+---
+
+## Task 9: Genre creation RPC
+
+Listing genres is a plain public SELECT (no RPC). Creating one is open to any member so the combobox vocabulary can grow.
+
+**Files:**
+- Create: `supabase/migrations/20260712000900_rpc_genres.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; expect failure)
+
+```sql
+begin;
+do $$
+declare _uid uuid; _artist uuid; _gid uuid; _slug text;
+begin
+  select id into _uid from auth.users limit 1;
+  assert _uid is not null, 'need an auth user to impersonate';
+  insert into public.artists (name) values ('Genre RPC Artist') returning id into _artist;
+  insert into public.artist_members (artist_id, user_id, role) values (_artist, _uid, 'owner');
+
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+  _gid := (public.create_genre('Dream Pop')).id;
+  select slug into _slug from public.genres where id = _gid;
+  assert _slug = 'dream-pop', 'genre slug generated (got ' || coalesce(_slug,'<null>') || ')';
+
+  -- a non-member (random uid, not in artist_members) may not create genres
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', gen_random_uuid(), 'role','authenticated')::text, true);
+  begin
+    perform public.create_genre('Should Fail');
+    assert false, 'non-member create_genre should raise';
+  exception when insufficient_privilege then null;
+  end;
+
+  raise notice 'Task 9 verification passed';
+end $$;
+rollback;
+```
+
+- [ ] **Step 2: Run it — expect failure** (`function public.create_genre(text) does not exist`).
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712000900_rpc_genres.sql
+-- Any authenticated artist_member may extend the genre vocabulary.
+
+create or replace function public.create_genre(_name text)
+  returns public.genres
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _g public.genres;
+begin
+  if not exists (select 1 from public.artist_members where user_id = auth.uid()) then
+    raise exception 'only artist members may create genres' using errcode = '42501';
+  end if;
+  insert into public.genres (name) values (_name)
+    on conflict (name) do update set name = excluded.name
+    returning * into _g;
+  return _g;
+end $$;
+
+revoke all on function public.create_genre(text) from public;
+grant execute on function public.create_genre(text) to authenticated;
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (member creates `dream-pop`; anon rejected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712000900_rpc_genres.sql
+git commit -m "feat(db): create_genre RPC for members"
+```
+
+---
+
+## Task 10: Storage buckets + write policies
+
+Audio lives in the existing public `songs` bucket. Covers need a public `covers`
+bucket. Both allow writes only to authenticated artist members (coarse policy for
+the single-artist phase — see spec §7). Functional upload testing happens via the
+app in Plan 2; here we create the bucket and policies and verify the policies exist.
+
+**Files:**
+- Create: `supabase/migrations/20260712001000_storage_policies.sql`
+
+- [ ] **Step 1: Write the verification block** (run now; the policy-count assert should fail until applied)
+
+```sql
+do $$
+declare n int;
+begin
+  select count(*) into n from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname in (
+        'members write songs','members update songs','members delete songs',
+        'members write covers','members update covers','members delete covers');
+  assert n = 6, 'expected 6 storage write policies for members';
+  assert exists (select 1 from storage.buckets where id='covers' and public), 'covers bucket public';
+  assert exists (select 1 from storage.buckets where id='songs'  and public), 'songs bucket public';
+end $$;
+```
+
+- [ ] **Step 2: Run it — expect failure** (assert fails: 0 policies / no covers bucket).
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260712001000_storage_policies.sql
+-- Public covers bucket + member-only write policies on songs and covers.
+
+insert into storage.buckets (id, name, public)
+  values ('covers', 'covers', true)
+  on conflict (id) do update set public = true;
+
+-- Ensure songs stays public (it already exists).
+update storage.buckets set public = true where id = 'songs';
+
+-- Helper: is the caller a member of ANY artist? (coarse; tighten to per-artist
+-- path parsing when the platform opens up — spec §7.)
+create or replace function public.is_any_artist_member()
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (select 1 from public.artist_members where user_id = auth.uid());
+$$;
+grant execute on function public.is_any_artist_member() to authenticated, anon;
+
+-- songs bucket
+drop policy if exists "members write songs" on storage.objects;
+create policy "members write songs" on storage.objects for insert to authenticated
+  with check (bucket_id = 'songs' and public.is_any_artist_member());
+drop policy if exists "members update songs" on storage.objects;
+create policy "members update songs" on storage.objects for update to authenticated
+  using (bucket_id = 'songs' and public.is_any_artist_member());
+drop policy if exists "members delete songs" on storage.objects;
+create policy "members delete songs" on storage.objects for delete to authenticated
+  using (bucket_id = 'songs' and public.is_any_artist_member());
+
+-- covers bucket
+drop policy if exists "members write covers" on storage.objects;
+create policy "members write covers" on storage.objects for insert to authenticated
+  with check (bucket_id = 'covers' and public.is_any_artist_member());
+drop policy if exists "members update covers" on storage.objects;
+create policy "members update covers" on storage.objects for update to authenticated
+  using (bucket_id = 'covers' and public.is_any_artist_member());
+drop policy if exists "members delete covers" on storage.objects;
+create policy "members delete covers" on storage.objects for delete to authenticated
+  using (bucket_id = 'covers' and public.is_any_artist_member());
+```
+
+- [ ] **Step 4: Apply the migration.**
+
+- [ ] **Step 5: Re-run the verification block — expect success** (6 policies present; both buckets public).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260712001000_storage_policies.sql
+git commit -m "feat(storage): covers bucket + member-only write policies"
+```
+
+---
+
+## Task 11: Seed your ownership + smoke-test end to end
+
+Wire your own account as `owner` of `bohns`, then run one non-rollback smoke test to confirm the whole chain works against real data (create → version → cleanup).
+
+**Files:** none (manual SQL, documented in the spec §9).
+
+- [ ] **Step 1: Find your user id and the bohns artist id**
+
+```sql
+select id, email from auth.users;                 -- copy your id
+select id, name from public.artists where name='bohns';
+```
+
+- [ ] **Step 2: Insert your ownership** (persists — this is intentional)
+
+```sql
+-- Seed yourself as owner of bohns, matched by your Google login email.
+insert into public.artist_members (artist_id, user_id, role)
+select a.id, u.id, 'owner'
+from public.artists a
+join auth.users u on u.email = 'hello@bohns.design'   -- your login email
+where a.name = 'bohns'
+on conflict (artist_id, user_id) do update set role = 'owner';
+```
+
+- [ ] **Step 3: Smoke-test end to end, then clean up** (self-contained; discards its fixtures)
+
+```sql
+begin;
+do $$
+declare _artist uuid; _uid uuid; _album uuid; _tid uuid; _vid uuid; _path text;
+begin
+  select id into _artist from public.artists where name = 'bohns' limit 1;
+  assert _artist is not null, 'bohns artist must exist';
+  select user_id into _uid from public.artist_members
+    where artist_id = _artist and role = 'owner' limit 1;
+  assert _uid is not null, 'seed an owner first (Step 2)';
+
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', _uid, 'role','authenticated')::text, true);
+
+  _album := (public.create_album(_artist, '__smoke__', 'album', null, '{}')).id;
+  _tid  := (public.create_track(_album, '__smoke_track__', null, null)).id;
+  select version_id, upload_path into _vid, _path
+    from public.create_version(_tid, '__smoke_ver__', 'demo', current_date);
+
+  assert (select artist_id from public.albums where id = _album) = _artist, 'smoke album owned by bohns';
+  raise notice 'end-to-end OK — sample upload_path = %', _path;
+end $$;
+rollback;   -- discard the smoke fixtures; your ownership row from Step 2 persists
+```
+
+Expected: a `NOTICE` printing a well-formed `upload_path`; no errors; the `bohns` membership row from Step 2 persists while the smoke album/track/version are rolled back.
+
+- [ ] **Step 4: Commit a short runbook note**
+
+```bash
+# Record the seeding step so it's reproducible (no schema change).
+git commit --allow-empty -m "docs: seed bohns ownership; API foundation verified end to end"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** artists/roles (T1), genres m2m (T2, T9), albums.artist_id (T3), setlist position (T4), write lockdown + public read (T5), album/track/version RPCs (T6–T8), storage buckets/policies (T10), manual ownership seeding (T11). `track_overview` is intentionally **not** modified here — read-ordering by `position` and any view changes belong to Plan 2 (UI), which consumes these RPCs.
+- **Deferred (not this plan):** Works/variants, per-track cover editing, tightened per-artist storage policies, the inline edit UI.
+- **Refinement vs spec §6:** `set_version_file` / `set_album_cover` take the SDK-derived public URL as an argument rather than recomputing it in SQL — this keeps the base URL out of the database (no project-ref config in Postgres) while remaining fully machine-written. Flag for Plan 2: the client must call `supabase.storage.from(bucket).getPublicUrl(path)` and pass `.data.publicUrl`.

--- a/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
+++ b/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
@@ -242,7 +242,7 @@ alter table public.albums
   add column if not exists artist_id uuid references public.artists(id);
 
 update public.albums
-  set artist_id = (select id from public.artists where name = 'bohns' limit 1)
+  set artist_id = (select id from public.artists where lower(name) = 'bohns' limit 1)
   where artist_id is null;
 ```
 
@@ -1133,7 +1133,7 @@ Wire your own account as `owner` of `bohns`, then run one non-rollback smoke tes
 
 ```sql
 select id, email from auth.users;                 -- copy your id
-select id, name from public.artists where name='bohns';
+select id, name from public.artists where lower(name) = 'bohns';
 ```
 
 - [ ] **Step 2: Insert your ownership** (persists — this is intentional)
@@ -1144,7 +1144,7 @@ insert into public.artist_members (artist_id, user_id, role)
 select a.id, u.id, 'owner'
 from public.artists a
 join auth.users u on u.email = 'hello@bohns.design'   -- your login email
-where a.name = 'bohns'
+where lower(a.name) = 'bohns'
 on conflict (artist_id, user_id) do update set role = 'owner';
 ```
 
@@ -1155,7 +1155,7 @@ begin;
 do $$
 declare _artist uuid; _uid uuid; _album uuid; _tid uuid; _vid uuid; _path text;
 begin
-  select id into _artist from public.artists where name = 'bohns' limit 1;
+  select id into _artist from public.artists where lower(name) = 'bohns' limit 1;
   assert _artist is not null, 'bohns artist must exist';
   select user_id into _uid from public.artist_members
     where artist_id = _artist and role = 'owner' limit 1;

--- a/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
+++ b/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
@@ -1046,10 +1046,11 @@ git commit -m "feat(db): create_genre RPC for members"
 
 ## Task 10: Storage buckets + write policies
 
-Audio lives in the existing public `songs` bucket. Covers need a public `covers`
-bucket. Both allow writes only to authenticated artist members (coarse policy for
-the single-artist phase — see spec §7). Functional upload testing happens via the
-app in Plan 2; here we create the bucket and policies and verify the policies exist.
+Audio lives in the existing public **`versions`** bucket (the audio bucket's id is
+`versions`, not `songs`); covers live in the existing public **`covers`** bucket.
+Both allow writes only to authenticated artist members (coarse policy for the
+single-artist phase — see spec §7). Functional upload testing happens via the app
+in Plan 2; here we set the policies and verify they exist.
 
 **Files:**
 - Create: `supabase/migrations/20260712001000_storage_policies.sql`
@@ -1063,28 +1064,25 @@ begin
   select count(*) into n from pg_policies
     where schemaname='storage' and tablename='objects'
       and policyname in (
-        'members write songs','members update songs','members delete songs',
+        'members write versions','members update versions','members delete versions',
         'members write covers','members update covers','members delete covers');
-  assert n = 6, 'expected 6 storage write policies for members';
-  assert exists (select 1 from storage.buckets where id='covers' and public), 'covers bucket public';
-  assert exists (select 1 from storage.buckets where id='songs'  and public), 'songs bucket public';
+  assert n = 6, 'expected 6 storage write policies for members (found ' || n || ')';
+  assert exists (select 1 from storage.buckets where id='covers'   and public), 'covers bucket public';
+  assert exists (select 1 from storage.buckets where id='versions' and public), 'versions bucket public';
+  raise notice 'Task 10 verification passed';
 end $$;
 ```
 
-- [ ] **Step 2: Run it — expect failure** (assert fails: 0 policies / no covers bucket).
+- [ ] **Step 2: Run it — expect failure** (assert fails: fewer than 6 policies).
 
 - [ ] **Step 3: Write the migration**
 
 ```sql
 -- supabase/migrations/20260712001000_storage_policies.sql
--- Public covers bucket + member-only write policies on songs and covers.
+-- Member-only write policies on the versions (audio) and covers buckets.
+-- Both buckets already exist and are public.
 
-insert into storage.buckets (id, name, public)
-  values ('covers', 'covers', true)
-  on conflict (id) do update set public = true;
-
--- Ensure songs stays public (it already exists).
-update storage.buckets set public = true where id = 'songs';
+update storage.buckets set public = true where id in ('versions','covers');
 
 -- Helper: is the caller a member of ANY artist? (coarse; tighten to per-artist
 -- path parsing when the platform opens up — spec §7.)
@@ -1095,16 +1093,21 @@ as $$
 $$;
 grant execute on function public.is_any_artist_member() to authenticated, anon;
 
--- songs bucket
-drop policy if exists "members write songs" on storage.objects;
-create policy "members write songs" on storage.objects for insert to authenticated
-  with check (bucket_id = 'songs' and public.is_any_artist_member());
+-- Clean up any earlier policies that targeted a mis-named 'songs' bucket.
+drop policy if exists "members write songs"  on storage.objects;
 drop policy if exists "members update songs" on storage.objects;
-create policy "members update songs" on storage.objects for update to authenticated
-  using (bucket_id = 'songs' and public.is_any_artist_member());
 drop policy if exists "members delete songs" on storage.objects;
-create policy "members delete songs" on storage.objects for delete to authenticated
-  using (bucket_id = 'songs' and public.is_any_artist_member());
+
+-- versions bucket (audio)
+drop policy if exists "members write versions" on storage.objects;
+create policy "members write versions" on storage.objects for insert to authenticated
+  with check (bucket_id = 'versions' and public.is_any_artist_member());
+drop policy if exists "members update versions" on storage.objects;
+create policy "members update versions" on storage.objects for update to authenticated
+  using (bucket_id = 'versions' and public.is_any_artist_member());
+drop policy if exists "members delete versions" on storage.objects;
+create policy "members delete versions" on storage.objects for delete to authenticated
+  using (bucket_id = 'versions' and public.is_any_artist_member());
 
 -- covers bucket
 drop policy if exists "members write covers" on storage.objects;

--- a/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
+++ b/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
@@ -887,7 +887,15 @@ begin
   insert into public.versions (name, status, release_date, track_id)
     values (_name, _status, _release_date, _track_id)
     returning id into _vid;
-  insert into public.track_versions (track_id, version_id) values (_track_id, _vid);
+  -- A trigger auto-links track_versions from versions.track_id. Keep this
+  -- idempotent (works with or without the trigger) and table-qualified so
+  -- version_id is unambiguous against the OUT parameter of the same name.
+  insert into public.track_versions (track_id, version_id)
+  select _track_id, _vid
+  where not exists (
+    select 1 from public.track_versions tv
+    where tv.track_id = _track_id and tv.version_id = _vid
+  );
   version_id  := _vid;
   upload_path := _slug || '-' || _tid || '/' || _slug || '-' || _vid || '.m4a';
   return next;

--- a/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
+++ b/docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md
@@ -81,18 +81,14 @@ create table if not exists public.artist_members (
 
 alter table public.artist_members enable row level security;
 
--- A member may read the membership rows of artists they belong to. No client
--- writes: memberships are seeded manually in the dashboard for now.
+-- A member may read their own membership rows (enough to compute canEdit). This
+-- is intentionally non-recursive: a policy that sub-queries artist_members would
+-- trigger "infinite recursion detected in policy". No client writes: memberships
+-- are seeded manually in the dashboard for now.
 drop policy if exists "members read own artist memberships" on public.artist_members;
 create policy "members read own artist memberships"
   on public.artist_members for select
-  using (
-    exists (
-      select 1 from public.artist_members m
-      where m.artist_id = artist_members.artist_id
-        and m.user_id = auth.uid()
-    )
-  );
+  using (user_id = auth.uid());
 
 -- SECURITY DEFINER so it can read artist_members regardless of the caller's RLS.
 create or replace function public.is_artist_member(_artist_id uuid)

--- a/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
+++ b/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
@@ -936,12 +936,13 @@ export default function GenrePicker({
 .input { font: inherit; font-size: 13px; padding: 4px 8px; border-radius: 6px;
   border: 1px solid rgba(128,128,128,0.35); background: transparent; color: inherit; width: 100%; max-width: 220px; }
 .menu { position: absolute; z-index: 20; margin-top: 2px; list-style: none; padding: 4px;
-  border-radius: 8px; background: var(--background, #fff); box-shadow: 0 6px 20px rgba(0,0,0,0.18);
+  border-radius: 8px; background: var(--album-deep, #1c1420); color: var(--album-light, #f2eff5);
+  border: 1px solid rgba(255,255,255,0.12); box-shadow: 0 10px 30px rgba(0,0,0,0.5);
   max-height: 200px; overflow-y: auto; min-width: 200px; }
 .menu button { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left;
   font: inherit; font-size: 13px; padding: 6px 8px; border: none; background: none; color: inherit;
   cursor: pointer; border-radius: 6px; }
-.menu button:hover { background: rgba(128,128,128,0.12); }
+.menu button:hover { background: rgba(255,255,255,0.12); }
 .create { color: #5b8cff; }
 ```
 

--- a/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
+++ b/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
@@ -1,0 +1,1472 @@
+# Inline Edit UI — Implementation Plan (Plan 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a member-gated, WYSIWYG inline edit mode to the album page so an artist can edit an album (name / description / type / genres / cover), manage its setlist (add / remove / move tracks), and manage each track's versions (upload audio) — all against the verified RPCs from Plan 1.
+
+**Architecture:** A `"use client"` `AlbumEditProvider` (mirroring the existing `LikesProvider` pattern — memoized browser Supabase client, optimistic updates, rollback) determines `canEdit` client-side by reading the current user's `artist_members` rows, and holds **staged** album/setlist edits committed on an explicit **Save** (Cancel discards). File uploads (cover, audio) are **immediate** discrete actions, since a binary can't stage and `create_version` must create the row before an upload path exists. All mutations go through a thin typed client-side "edit API" (`src/lib/edit.ts`) that wraps the Plan 1 RPCs + Storage. The listener render path is untouched when not editing.
+
+**Tech Stack:** Next.js 16 App Router, React 19, `@supabase/ssr` browser client, `lucide-react` icons, CSS Modules. **No new dependencies** (reorder uses up/down controls).
+
+**Spec:** `docs/superpowers/specs/2026-07-12-artist-content-management-design.md` (§8)
+**Depends on:** Plan 1 (`docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md`) — applied & verified.
+
+---
+
+## Conventions for every task
+
+**No automated tests** (established: no test framework, manual verification via the app). Each task ends with a **manual verification** run against `npm run dev`, signed in as your owner account (the Bohns owner seeded in Plan 1). A second, signed-out browser confirms listeners never see edit affordances.
+
+**Bucket ids (from Plan 1):** audio → `versions`, covers → `covers`. **Album has no `slug` column**, so cover objects are keyed by album id.
+
+**Commit** one focused commit per task.
+
+**File map (created/modified across the plan):**
+- `src/lib/types.ts` — *modify*: add `artist_id` to `Album`; add `Genre`, `AlbumVersion`.
+- `src/lib/data.ts` — *modify*: album detail fetch gains `artist_id`, genres, position-ordered tracks; add `getGenres`.
+- `src/lib/edit.ts` — *create*: typed client wrappers over the Plan 1 RPCs + Storage.
+- `src/components/edit/AlbumEditProvider.tsx` — *create*: edit state + save/cancel + canEdit.
+- `src/components/edit/EditToggle.tsx` — *create*: Edit / Save+Cancel controls.
+- `src/components/edit/EditableText.tsx` — *create*: contenteditable field.
+- `src/components/edit/AlbumTypeSelect.tsx`, `GenrePicker.tsx`, `CoverUploader.tsx` — *create*.
+- `src/components/edit/EditableSetlist.tsx`, `VersionsPanel.tsx` — *create*.
+- `src/components/AlbumDetailCard.tsx` — *modify*: consume edit context, render editable variants when `editing`.
+- `src/app/albums/[id]/page.tsx` — *modify*: fetch richer album, wrap card in provider.
+
+---
+
+## Task 1: Data layer — artist_id, genres, position order, genre list
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/data.ts`
+
+- [ ] **Step 1: Extend the types**
+
+In `src/lib/types.ts`, add `artist_id` to `Album` and add two new types:
+
+```ts
+export type Album = {
+  id: string;
+  artist_id: string | null;
+  name: string;
+  description: string | null;
+  type: string | null;
+  cover_url: string | null;
+  created_at: string;
+};
+
+export type Genre = { id: string; name: string; slug: string };
+
+/** A full row of public.versions (edit view — the read view uses Track). */
+export type AlbumVersion = {
+  id: string;
+  name: string;
+  status: string;
+  release_date: string;
+  resource_url: string | null;
+};
+```
+
+`AlbumWithTracks` gains genres:
+
+```ts
+export type AlbumWithTracks = Album & {
+  tracks: Track[];
+  genres: Genre[];
+};
+```
+
+- [ ] **Step 2: Fetch artist_id, genres, and position-ordered tracks**
+
+In `src/lib/data.ts`, add `artist_id` to the album columns and enrich the single-album fetch. Replace the `ALBUM_COLS` constant and `getAlbumWithTracks`, and add `getGenres`:
+
+```ts
+const ALBUM_COLS = "id,artist_id,name,description,type,cover_url,created_at";
+
+export async function getAlbumWithTracks(
+  id: string
+): Promise<AlbumWithTracks | null> {
+  const [albumRes, tracksRes, orderRes, genresRes] = await Promise.all([
+    supabase.from("albums").select(ALBUM_COLS).eq("id", id).maybeSingle(),
+    supabase.from("track_overview").select(TRACK_COLS).eq("album_id", id),
+    supabase.from("album_tracks").select("track_id,position").eq("album_id", id),
+    supabase
+      .from("album_genres")
+      .select("genres(id,name,slug)")
+      .eq("album_id", id),
+  ]);
+
+  if (albumRes.error || !albumRes.data) return null;
+  if (tracksRes.error) fail("Failed to load album tracks", tracksRes.error);
+
+  const position = new Map(
+    (orderRes.data ?? []).map((r) => [r.track_id as string, r.position as number])
+  );
+  const tracks = ((tracksRes.data ?? []) as Track[]).slice().sort(
+    (a, b) =>
+      (position.get(a.track_id) ?? Number.MAX_SAFE_INTEGER) -
+      (position.get(b.track_id) ?? Number.MAX_SAFE_INTEGER)
+  );
+
+  const genres = (genresRes.data ?? [])
+    .map((row) => (row as { genres: Genre | null }).genres)
+    .filter((g): g is Genre => Boolean(g));
+
+  return { ...(albumRes.data as Album), tracks, genres };
+}
+
+/** All genres, alphabetical — powers the edit combobox. */
+export async function getGenres(): Promise<Genre[]> {
+  const { data, error } = await supabase
+    .from("genres")
+    .select("id,name,slug")
+    .order("name");
+  if (error) fail("Failed to load genres", error);
+  return (data ?? []) as Genre[];
+}
+```
+
+Add `Genre` to the type import at the top of `data.ts`:
+
+```ts
+import type { Album, AlbumWithTracks, Genre, Track, TrackLyrics } from "./types";
+```
+
+> Note: `getAlbumsWithTracks` (the plural, used by `AlbumSwitcher`) is unchanged; it returns `genres: []`-free `AlbumWithTracks` via `groupTracks`. Update `groupTracks` to include `genres: []` so the type is satisfied:
+
+```ts
+return albums.map((album) => ({
+  ...album,
+  tracks: byAlbum.get(album.id) ?? [],
+  genres: [],
+}));
+```
+
+- [ ] **Step 3: Point the album page at the enriched fetch**
+
+In `src/app/albums/[id]/page.tsx`, keep `getAlbumsWithTracks()` for the switcher, but fetch the detailed album via `getAlbumWithTracks(id)` and pass THAT to the card:
+
+```tsx
+import { getAlbumsWithTracks, getAlbumWithTracks, getLyrics } from "@/lib/data";
+// ...
+export default async function AlbumPage({ params }: Props) {
+  const { id } = await params;
+
+  const [albums, album] = await Promise.all([
+    getAlbumsWithTracks(),
+    getAlbumWithTracks(id),
+  ]);
+  if (!album) notFound();
+
+  const lyrics = await getLyrics(album.tracks.map((t) => t.track_id));
+
+  return (
+    <div className={styles.page}>
+      <Header variant="compact" />
+      <div className={styles.content}>
+        <AlbumSwitcher albums={albums} activeId={album.id} />
+        <AlbumDetailCard album={album} lyrics={lyrics} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Manual verification**
+
+Run `npm run dev`, open an album page. Confirm: (a) it still renders; (b) tracks now appear in **setlist/position order** (matching `album_tracks.position`, not release date); (c) no console errors. In the browser devtools Network tab you can confirm the `album_genres` request returns the album's genres.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/data.ts src/app/albums/\[id\]/page.tsx
+git commit -m "feat(ui): album detail fetch gains artist_id, genres, setlist order"
+```
+
+---
+
+## Task 2: The edit API wrapper (`src/lib/edit.ts`)
+
+A single typed module wrapping every Plan 1 RPC + Storage call the UI needs. DRY: every component calls these, not `supabase.rpc` directly.
+
+**Files:**
+- Create: `src/lib/edit.ts`
+
+- [ ] **Step 1: Write the module**
+
+```ts
+import { createClient } from "@/lib/supabase/client";
+import type { AlbumVersion, Genre } from "@/lib/types";
+
+/** Artist ids the signed-in user may edit (own artist_members rows, RLS-scoped). */
+export async function getMyArtistIds(): Promise<Set<string>> {
+  const supabase = createClient();
+  const { data, error } = await supabase.from("artist_members").select("artist_id");
+  if (error) throw new Error(error.message);
+  return new Set((data ?? []).map((r) => r.artist_id as string));
+}
+
+export async function updateAlbum(
+  albumId: string,
+  name: string,
+  description: string | null,
+  type: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("update_album", {
+    _album_id: albumId,
+    _name: name,
+    _description: description,
+    _type: type,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function setAlbumGenres(albumId: string, genreIds: string[]): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("set_album_genres", {
+    _album_id: albumId,
+    _genre_ids: genreIds,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function createGenre(name: string): Promise<Genre> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_genre", { _name: name });
+  if (error) throw new Error(error.message);
+  return data as Genre;
+}
+
+export async function createTrack(albumId: string, name: string): Promise<string> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_track", {
+    _album_id: albumId,
+    _name: name,
+    _description: null,
+    _lyrics: null,
+  });
+  if (error) throw new Error(error.message);
+  return (data as { id: string }).id;
+}
+
+export async function removeTrackFromAlbum(albumId: string, trackId: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("remove_track_from_album", {
+    _album_id: albumId,
+    _track_id: trackId,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function reorderSetlist(albumId: string, orderedTrackIds: string[]): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("reorder_setlist", {
+    _album_id: albumId,
+    _ordered_track_ids: orderedTrackIds,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** Upload a cover to the `covers` bucket and record its public URL. */
+export async function uploadAlbumCover(albumId: string, file: File): Promise<string> {
+  const supabase = createClient();
+  const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+  const path = `${albumId}/cover.${ext}`;
+  const up = await supabase.storage.from("covers").upload(path, file, { upsert: true });
+  if (up.error) throw new Error(up.error.message);
+  const url = supabase.storage.from("covers").getPublicUrl(path).data.publicUrl;
+  const { error } = await supabase.rpc("set_album_cover", {
+    _album_id: albumId,
+    _cover_url: url,
+  });
+  if (error) throw new Error(error.message);
+  return url;
+}
+
+/** All versions of a track, newest release first (edit view). */
+export async function listTrackVersions(trackId: string): Promise<AlbumVersion[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("track_versions")
+    .select("versions(id,name,status,release_date,resource_url)")
+    .eq("track_id", trackId);
+  if (error) throw new Error(error.message);
+  return (data ?? [])
+    .map((row) => (row as { versions: AlbumVersion | null }).versions)
+    .filter((v): v is AlbumVersion => Boolean(v))
+    .sort((a, b) => b.release_date.localeCompare(a.release_date));
+}
+
+export async function updateVersion(
+  versionId: string,
+  name: string,
+  status: string,
+  releaseDate: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("update_version", {
+    _version_id: versionId,
+    _name: name,
+    _status: status,
+    _release_date: releaseDate,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function deleteVersion(versionId: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("delete_version", { _version_id: versionId });
+  if (error) throw new Error(error.message);
+}
+
+/** Create a version row, upload its audio, and record the URL. Returns the id. */
+export async function createVersionWithFile(
+  trackId: string,
+  name: string,
+  status: string,
+  releaseDate: string,
+  file: File
+): Promise<string> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_version", {
+    _track_id: trackId,
+    _name: name,
+    _status: status,
+    _release_date: releaseDate,
+  });
+  if (error) throw new Error(error.message);
+  const { version_id, upload_path } = data as { version_id: string; upload_path: string };
+
+  const up = await supabase.storage.from("versions").upload(upload_path, file, { upsert: true });
+  if (up.error) throw new Error(up.error.message);
+  const url = supabase.storage.from("versions").getPublicUrl(upload_path).data.publicUrl;
+
+  const setErr = (
+    await supabase.rpc("set_version_file", { _version_id: version_id, _resource_url: url })
+  ).error;
+  if (setErr) throw new Error(setErr.message);
+  return version_id;
+}
+
+export const VERSION_STATUSES = ["raw", "draft", "demo", "prototype", "final"] as const;
+export const ALBUM_TYPES = ["single", "ep", "album"] as const;
+```
+
+- [ ] **Step 2: Manual verification** — none yet (no callers). Confirm it type-checks: `npx tsc --noEmit` should report no errors in `src/lib/edit.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/edit.ts
+git commit -m "feat(ui): typed client edit API over Plan 1 RPCs + storage"
+```
+
+---
+
+## Task 3: Edit provider + Edit toggle (canEdit, editing state)
+
+**Files:**
+- Create: `src/components/edit/AlbumEditProvider.tsx`
+- Create: `src/components/edit/EditToggle.tsx`
+- Create: `src/components/edit/EditToggle.module.css`
+- Modify: `src/app/albums/[id]/page.tsx` (wrap card)
+- Modify: `src/components/AlbumDetailCard.tsx` (render the toggle)
+
+- [ ] **Step 1: Write the provider**
+
+`src/components/edit/AlbumEditProvider.tsx` — holds `canEdit`, `editing`, and staged album-field state. (Setlist + versions state is added in later tasks; this task establishes the provider + save/cancel scaffold for album fields only.)
+
+```tsx
+"use client";
+
+import {
+  createContext, useCallback, useContext, useEffect, useMemo, useState,
+} from "react";
+import type { AlbumWithTracks } from "@/lib/types";
+import { getMyArtistIds, updateAlbum } from "@/lib/edit";
+
+type Draft = { name: string; description: string; type: string };
+
+type EditContextValue = {
+  canEdit: boolean;
+  editing: boolean;
+  saving: boolean;
+  dirty: boolean;
+  draft: Draft;
+  startEditing: () => void;
+  cancel: () => void;
+  save: () => Promise<void>;
+  setField: <K extends keyof Draft>(key: K, value: Draft[K]) => void;
+  album: AlbumWithTracks;
+};
+
+const EditContext = createContext<EditContextValue | null>(null);
+
+export function useAlbumEdit(): EditContextValue {
+  const ctx = useContext(EditContext);
+  if (!ctx) throw new Error("useAlbumEdit must be used within <AlbumEditProvider>");
+  return ctx;
+}
+
+function draftFrom(album: AlbumWithTracks): Draft {
+  return {
+    name: album.name,
+    description: album.description ?? "",
+    type: album.type ?? "album",
+  };
+}
+
+export function AlbumEditProvider({
+  album,
+  children,
+}: {
+  album: AlbumWithTracks;
+  children: React.ReactNode;
+}) {
+  const [canEdit, setCanEdit] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [draft, setDraft] = useState<Draft>(() => draftFrom(album));
+
+  useEffect(() => {
+    let active = true;
+    getMyArtistIds()
+      .then((ids) => {
+        if (active) setCanEdit(album.artist_id ? ids.has(album.artist_id) : false);
+      })
+      .catch(() => {
+        if (active) setCanEdit(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [album.artist_id]);
+
+  const dirty = useMemo(
+    () =>
+      draft.name !== album.name ||
+      draft.description !== (album.description ?? "") ||
+      draft.type !== (album.type ?? "album"),
+    [draft, album]
+  );
+
+  const startEditing = useCallback(() => setEditing(true), []);
+
+  const cancel = useCallback(() => {
+    setDraft(draftFrom(album));
+    setEditing(false);
+  }, [album]);
+
+  const setField = useCallback(
+    <K extends keyof Draft>(key: K, value: Draft[K]) =>
+      setDraft((d) => ({ ...d, [key]: value })),
+    []
+  );
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      if (dirty) {
+        await updateAlbum(album.id, draft.name, draft.description || null, draft.type);
+      }
+      setEditing(false);
+      // Reflect the saved values without a full reload.
+      album.name = draft.name;
+      album.description = draft.description || null;
+      album.type = draft.type;
+    } catch (err) {
+      console.error("Save failed", err);
+      alert("Save failed: " + (err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [album, draft, dirty]);
+
+  const value = useMemo<EditContextValue>(
+    () => ({
+      canEdit, editing, saving, dirty, draft,
+      startEditing, cancel, save, setField, album,
+    }),
+    [canEdit, editing, saving, dirty, draft, startEditing, cancel, save, setField, album]
+  );
+
+  return <EditContext.Provider value={value}>{children}</EditContext.Provider>;
+}
+```
+
+> Note: mutating `album.name` after save is a pragmatic local reflect (the object is client-owned on this page). A later task can switch to `router.refresh()` if you prefer server round-trips; for now it avoids a flash.
+
+- [ ] **Step 2: Write the toggle**
+
+`src/components/edit/EditToggle.tsx`:
+
+```tsx
+"use client";
+
+import { Pencil, Check, X } from "lucide-react";
+import { useAlbumEdit } from "./AlbumEditProvider";
+import styles from "./EditToggle.module.css";
+
+export default function EditToggle() {
+  const { canEdit, editing, saving, startEditing, cancel, save } = useAlbumEdit();
+  if (!canEdit) return null;
+
+  if (!editing) {
+    return (
+      <button type="button" className={styles.edit} onClick={startEditing} aria-label="Edit album">
+        <Pencil size={16} strokeWidth={2} />
+        <span>Edit</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.actions}>
+      <button type="button" className={styles.cancel} onClick={cancel} disabled={saving}>
+        <X size={16} strokeWidth={2} />
+        <span>Cancel</span>
+      </button>
+      <button type="button" className={styles.save} onClick={save} disabled={saving}>
+        <Check size={16} strokeWidth={2} />
+        <span>{saving ? "Saving…" : "Save"}</span>
+      </button>
+    </div>
+  );
+}
+```
+
+`src/components/edit/EditToggle.module.css`:
+
+```css
+.edit, .save, .cancel {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border-radius: 999px; font: inherit; font-size: 13px;
+  cursor: pointer; border: 1px solid rgba(128, 128, 128, 0.35);
+  background: rgba(128, 128, 128, 0.08); color: inherit;
+}
+.actions { display: inline-flex; gap: 8px; }
+.save { background: #5b8cff; border-color: #5b8cff; color: #fff; }
+.save:disabled, .cancel:disabled { opacity: 0.6; cursor: default; }
+```
+
+- [ ] **Step 3: Editable field components**
+
+`src/components/edit/EditableText.tsx` — a `contenteditable` element that commits to the draft on blur:
+
+```tsx
+"use client";
+
+import { useRef } from "react";
+
+type Props = {
+  value: string;
+  onCommit: (value: string) => void;
+  className?: string;
+  placeholder?: string;
+  multiline?: boolean;
+  ariaLabel: string;
+};
+
+export default function EditableText({
+  value, onCommit, className, placeholder, multiline = false, ariaLabel,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={ref}
+      role="textbox"
+      aria-label={ariaLabel}
+      contentEditable
+      suppressContentEditableWarning
+      className={className}
+      data-placeholder={placeholder}
+      style={{ outline: "1px dashed rgba(91,140,255,0.6)", borderRadius: 6, padding: "2px 6px", minHeight: "1em" }}
+      onKeyDown={(e) => {
+        if (!multiline && e.key === "Enter") {
+          e.preventDefault();
+          ref.current?.blur();
+        }
+      }}
+      onBlur={(e) => onCommit(e.currentTarget.textContent ?? "")}
+    >
+      {value}
+    </div>
+  );
+}
+```
+
+`src/components/edit/AlbumTypeSelect.tsx`:
+
+```tsx
+"use client";
+
+import { ALBUM_TYPES } from "@/lib/edit";
+
+export default function AlbumTypeSelect({
+  value, onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      aria-label="Album type"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ font: "inherit", padding: "4px 8px", borderRadius: 6 }}
+    >
+      {ALBUM_TYPES.map((t) => (
+        <option key={t} value={t}>
+          {t.charAt(0).toUpperCase() + t.slice(1)}
+        </option>
+      ))}
+    </select>
+  );
+}
+```
+
+- [ ] **Step 4: Make `AlbumDetailCard` edit-aware**
+
+Replace `src/components/AlbumDetailCard.tsx` entirely (it becomes a client component that reads the edit context; read mode renders exactly as before):
+
+```tsx
+"use client";
+
+import type { AlbumWithTracks, TrackLyrics } from "@/lib/types";
+import { getPalette, paletteVars } from "@/lib/palettes";
+import AlbumCover from "./AlbumCover";
+import AlbumHeader from "./AlbumHeader";
+import AlbumInfos from "./AlbumInfos";
+import AlbumMetaTiles from "./AlbumMetaTiles";
+import AlbumPlaylist from "./AlbumPlaylist";
+import EditToggle from "./edit/EditToggle";
+import EditableText from "./edit/EditableText";
+import AlbumTypeSelect from "./edit/AlbumTypeSelect";
+import { useAlbumEdit } from "./edit/AlbumEditProvider";
+import styles from "./AlbumDetailCard.module.css";
+
+type Props = { album: AlbumWithTracks; lyrics: TrackLyrics };
+
+export default function AlbumDetailCard({ album, lyrics }: Props) {
+  const { editing, draft, setField } = useAlbumEdit();
+  const palette = getPalette(album);
+
+  return (
+    <article className={styles.card} style={paletteVars(palette)}>
+      <div className={styles.editBar}>
+        <EditToggle />
+      </div>
+      <div className={styles.hero}>
+        <AlbumCover coverUrl={album.cover_url} alt={album.name} size={165} priority />
+        <div className={styles.heroBody}>
+          {editing ? (
+            <div className={styles.header}>
+              <EditableText
+                ariaLabel="Album name"
+                value={draft.name}
+                onCommit={(v) => setField("name", v)}
+                className={styles.nameEdit}
+              />
+              <AlbumInfos tracks={album.tracks} />
+            </div>
+          ) : (
+            <AlbumHeader album={album} />
+          )}
+
+          {editing ? (
+            <EditableText
+              ariaLabel="Album description"
+              multiline
+              value={draft.description}
+              placeholder="Add a description…"
+              onCommit={(v) => setField("description", v)}
+              className={styles.description}
+            />
+          ) : (
+            album.description && <p className={styles.description}>{album.description}</p>
+          )}
+
+          {editing ? (
+            <AlbumTypeSelect value={draft.type} onChange={(v) => setField("type", v)} />
+          ) : (
+            <AlbumMetaTiles
+              genre={palette.genre ?? capitalize(album.type)}
+              year={new Date(album.created_at).getFullYear().toString()}
+              direction="horizontal"
+            />
+          )}
+        </div>
+      </div>
+      <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />
+    </article>
+  );
+}
+
+function capitalize(value: string | null): string {
+  if (!value) return "Album";
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+```
+
+Add two style rules to `src/components/AlbumDetailCard.module.css` (append at the end):
+
+```css
+.editBar { display: flex; justify-content: flex-end; margin-bottom: 8px; }
+.nameEdit { font-size: 1.5rem; font-weight: 700; }
+```
+
+- [ ] **Step 5: Wrap the page in the provider**
+
+In `src/app/albums/[id]/page.tsx`, wrap the card:
+
+```tsx
+import { AlbumEditProvider } from "@/components/edit/AlbumEditProvider";
+// ...
+        <AlbumSwitcher albums={albums} activeId={album.id} />
+        <AlbumEditProvider album={album}>
+          <AlbumDetailCard album={album} lyrics={lyrics} />
+        </AlbumEditProvider>
+```
+
+- [ ] **Step 6: Manual verification**
+
+`npm run dev`. Signed in as the Bohns owner, open an album: an **Edit** button appears. Click it → name/description become editable, type becomes a select, and Save/Cancel appear. Change the name, click **Save**, reload → the change persisted. Repeat, change something, click **Cancel** → reverts. In a **signed-out** (or non-member) browser, **no Edit button** appears. Non-member safety is also enforced server-side by the RPCs (Plan 1).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/edit/AlbumEditProvider.tsx src/components/edit/EditToggle.tsx src/components/edit/EditToggle.module.css src/components/edit/EditableText.tsx src/components/edit/AlbumTypeSelect.tsx src/components/AlbumDetailCard.tsx src/components/AlbumDetailCard.module.css src/app/albums/\[id\]/page.tsx
+git commit -m "feat(ui): inline album edit mode — name/description/type with Save/Cancel"
+```
+
+---
+
+## Task 4: Genre picker (chips + searchable combobox + create)
+
+Extends the provider with staged `genreIds` and adds a custom combobox (no library).
+
+**Files:**
+- Modify: `src/components/edit/AlbumEditProvider.tsx` (stage genres, save them)
+- Create: `src/components/edit/GenrePicker.tsx`
+- Create: `src/components/edit/GenrePicker.module.css`
+- Modify: `src/components/AlbumDetailCard.tsx` (render `GenrePicker` in edit mode)
+
+- [ ] **Step 1: Add genres to the provider draft**
+
+In `AlbumEditProvider.tsx`, extend `Draft`, `draftFrom`, `dirty`, and `save`:
+
+```tsx
+type Draft = { name: string; description: string; type: string; genreIds: string[] };
+
+function draftFrom(album: AlbumWithTracks): Draft {
+  return {
+    name: album.name,
+    description: album.description ?? "",
+    type: album.type ?? "album",
+    genreIds: album.genres.map((g) => g.id),
+  };
+}
+```
+
+Add genres to `dirty` (compare as sorted joins):
+
+```tsx
+const dirty = useMemo(() => {
+  const a = draft.genreIds.slice().sort().join(",");
+  const b = album.genres.map((g) => g.id).slice().sort().join(",");
+  return (
+    draft.name !== album.name ||
+    draft.description !== (album.description ?? "") ||
+    draft.type !== (album.type ?? "album") ||
+    a !== b
+  );
+}, [draft, album]);
+```
+
+In `save`, after `updateAlbum`, persist genres and reflect them locally. Import `setAlbumGenres` and, for local reflect, you need the full `Genre` objects — accept them from the picker via a ref of known genres. Simplest: store the chosen `Genre[]` in the draft too. Replace `genreIds: string[]` handling by keeping `genres: Genre[]` in the draft instead:
+
+```tsx
+// Draft holds full Genre objects so we can reflect + compute chips without a refetch.
+type Draft = { name: string; description: string; type: string; genres: Genre[] };
+
+function draftFrom(album: AlbumWithTracks): Draft {
+  return {
+    name: album.name,
+    description: album.description ?? "",
+    type: album.type ?? "album",
+    genres: album.genres,
+  };
+}
+```
+
+Update `dirty` to compare `draft.genres.map(g=>g.id)`; update `save`:
+
+```tsx
+if (dirty) {
+  await updateAlbum(album.id, draft.name, draft.description || null, draft.type);
+  await setAlbumGenres(album.id, draft.genres.map((g) => g.id));
+}
+setEditing(false);
+album.name = draft.name;
+album.description = draft.description || null;
+album.type = draft.type;
+album.genres = draft.genres;
+```
+
+Add `Genre` to the type import and `setAlbumGenres` to the edit import. Expose `setField` (already generic over `keyof Draft`, so `setField("genres", nextGenres)` works).
+
+- [ ] **Step 2: Write the combobox**
+
+`src/components/edit/GenrePicker.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { X, Plus } from "lucide-react";
+import type { Genre } from "@/lib/types";
+import { getGenres } from "@/lib/data";
+import { createGenre } from "@/lib/edit";
+import styles from "./GenrePicker.module.css";
+
+export default function GenrePicker({
+  selected, onChange,
+}: {
+  selected: Genre[];
+  onChange: (genres: Genre[]) => void;
+}) {
+  const [all, setAll] = useState<Genre[]>([]);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    getGenres().then(setAll).catch((e) => console.error("load genres", e));
+  }, []);
+
+  const selectedIds = useMemo(() => new Set(selected.map((g) => g.id)), [selected]);
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return all.filter((g) => !selectedIds.has(g.id) && (!q || g.name.toLowerCase().includes(q)));
+  }, [all, query, selectedIds]);
+
+  const exact = all.some((g) => g.name.toLowerCase() === query.trim().toLowerCase());
+
+  function add(g: Genre) {
+    onChange([...selected, g]);
+    setQuery("");
+    setOpen(false);
+  }
+  function remove(id: string) {
+    onChange(selected.filter((g) => g.id !== id));
+  }
+  async function createAndAdd() {
+    const name = query.trim();
+    if (!name) return;
+    try {
+      const g = await createGenre(name);
+      setAll((prev) => (prev.some((x) => x.id === g.id) ? prev : [...prev, g]));
+      add(g);
+    } catch (e) {
+      console.error("create genre", e);
+      alert("Could not create genre: " + (e as Error).message);
+    }
+  }
+
+  return (
+    <div className={styles.picker}>
+      <div className={styles.chips}>
+        {selected.map((g) => (
+          <span key={g.id} className={styles.chip}>
+            {g.name}
+            <button type="button" aria-label={`Remove ${g.name}`} onClick={() => remove(g.id)}>
+              <X size={12} strokeWidth={2.5} />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className={styles.inputWrap}>
+        <input
+          className={styles.input}
+          value={query}
+          placeholder="Add genre…"
+          aria-label="Search or add genre"
+          onFocus={() => setOpen(true)}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+        />
+        {open && (matches.length > 0 || (query.trim() && !exact)) && (
+          <ul className={styles.menu}>
+            {matches.map((g) => (
+              <li key={g.id}>
+                <button type="button" onMouseDown={(e) => e.preventDefault()} onClick={() => add(g)}>
+                  {g.name}
+                </button>
+              </li>
+            ))}
+            {query.trim() && !exact && (
+              <li>
+                <button type="button" className={styles.create}
+                  onMouseDown={(e) => e.preventDefault()} onClick={createAndAdd}>
+                  <Plus size={14} strokeWidth={2.5} /> Create “{query.trim()}”
+                </button>
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+`src/components/edit/GenrePicker.module.css`:
+
+```css
+.picker { display: flex; flex-direction: column; gap: 6px; }
+.chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.chip { display: inline-flex; align-items: center; gap: 4px; font-size: 12px;
+  padding: 2px 8px; border-radius: 999px; background: rgba(91,140,255,0.15); color: #5b8cff; }
+.chip button { background: none; border: none; color: inherit; cursor: pointer; display: inline-flex; }
+.inputWrap { position: relative; }
+.input { font: inherit; font-size: 13px; padding: 4px 8px; border-radius: 6px;
+  border: 1px solid rgba(128,128,128,0.35); background: transparent; color: inherit; width: 100%; max-width: 220px; }
+.menu { position: absolute; z-index: 20; margin-top: 2px; list-style: none; padding: 4px;
+  border-radius: 8px; background: var(--background, #fff); box-shadow: 0 6px 20px rgba(0,0,0,0.18);
+  max-height: 200px; overflow-y: auto; min-width: 200px; }
+.menu button { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left;
+  font: inherit; font-size: 13px; padding: 6px 8px; border: none; background: none; color: inherit;
+  cursor: pointer; border-radius: 6px; }
+.menu button:hover { background: rgba(128,128,128,0.12); }
+.create { color: #5b8cff; }
+```
+
+- [ ] **Step 3: Render it in the card**
+
+In `AlbumDetailCard.tsx`, import `GenrePicker`, and in the `editing` branch render it under the type select:
+
+```tsx
+import GenrePicker from "./edit/GenrePicker";
+// ...
+{editing ? (
+  <>
+    <AlbumTypeSelect value={draft.type} onChange={(v) => setField("type", v)} />
+    <GenrePicker selected={draft.genres} onChange={(g) => setField("genres", g)} />
+  </>
+) : (
+  <AlbumMetaTiles /* …unchanged… */ />
+)}
+```
+
+- [ ] **Step 4: Manual verification**
+
+Edit mode: existing genres show as chips; typing filters the dropdown; picking one adds a chip; the ✕ removes it; typing a new name offers **Create "…"** which creates it (via `create_genre`) and adds it. **Save**, reload → chips persist. **Cancel** discards unsaved chip changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/edit/GenrePicker.tsx src/components/edit/GenrePicker.module.css src/components/edit/AlbumEditProvider.tsx src/components/AlbumDetailCard.tsx
+git commit -m "feat(ui): genre chip combobox with create, saved with the album"
+```
+
+---
+
+## Task 5: Cover uploader (immediate)
+
+**Files:**
+- Create: `src/components/edit/CoverUploader.tsx`
+- Create: `src/components/edit/CoverUploader.module.css`
+- Modify: `src/components/AlbumDetailCard.tsx` (swap cover in edit mode)
+
+- [ ] **Step 1: Write the uploader**
+
+`src/components/edit/CoverUploader.tsx` — wraps `AlbumCover`, adds a click-to-replace overlay, uploads immediately:
+
+```tsx
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload } from "lucide-react";
+import AlbumCover from "../AlbumCover";
+import { uploadAlbumCover } from "@/lib/edit";
+import styles from "./CoverUploader.module.css";
+
+export default function CoverUploader({
+  albumId, coverUrl, alt, size,
+}: {
+  albumId: string;
+  coverUrl: string | null;
+  alt: string;
+  size: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [url, setUrl] = useState(coverUrl);
+  const [busy, setBusy] = useState(false);
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setBusy(true);
+    try {
+      const next = await uploadAlbumCover(albumId, file);
+      // cache-bust so the <img> re-fetches the replaced object
+      setUrl(`${next}?v=${Date.now()}`);
+    } catch (err) {
+      console.error("cover upload", err);
+      alert("Cover upload failed: " + (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <AlbumCover coverUrl={url} alt={alt} size={size} priority />
+      <button
+        type="button"
+        className={styles.overlay}
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        aria-label="Replace cover"
+      >
+        <Upload size={20} strokeWidth={2} />
+        <span>{busy ? "Uploading…" : "Replace"}</span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={onPick}
+      />
+    </div>
+  );
+}
+```
+
+`src/components/edit/CoverUploader.module.css`:
+
+```css
+.wrap { position: relative; display: inline-block; }
+.overlay { position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 4px; border: none; cursor: pointer;
+  border-radius: 8px; color: #fff; font: inherit; font-size: 12px;
+  background: rgba(0,0,0,0.45); opacity: 0; transition: opacity 0.15s; }
+.wrap:hover .overlay, .overlay:focus-visible { opacity: 1; }
+.overlay:disabled { opacity: 1; cursor: default; }
+```
+
+Uses date-based cache-busting via `Date.now()` — acceptable in a client component (this is not a workflow script).
+
+- [ ] **Step 2: Swap the cover in edit mode**
+
+In `AlbumDetailCard.tsx`, import `CoverUploader` and branch the cover:
+
+```tsx
+import CoverUploader from "./edit/CoverUploader";
+// ...
+{editing ? (
+  <CoverUploader albumId={album.id} coverUrl={album.cover_url} alt={album.name} size={165} />
+) : (
+  <AlbumCover coverUrl={album.cover_url} alt={album.name} size={165} priority />
+)}
+```
+
+- [ ] **Step 3: Manual verification**
+
+In edit mode, hover the cover → a **Replace** overlay appears. Pick an image → it uploads to the `covers` bucket and the cover updates in place. Reload → the new cover persists (it was written by `set_album_cover` immediately, independent of Save).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/edit/CoverUploader.tsx src/components/edit/CoverUploader.module.css src/components/AlbumDetailCard.tsx
+git commit -m "feat(ui): click-to-replace album cover upload"
+```
+
+---
+
+## Task 6: Editable setlist (move up/down, remove, add)
+
+Adds staged setlist structure to the provider and an editable list. Order/membership commit on **Save**; new tracks are created then; removed tracks are unlinked then.
+
+**Files:**
+- Modify: `src/components/edit/AlbumEditProvider.tsx` (staged setlist + commit)
+- Create: `src/components/edit/EditableSetlist.tsx`
+- Create: `src/components/edit/EditableSetlist.module.css`
+- Modify: `src/components/AlbumDetailCard.tsx` (swap playlist in edit mode)
+
+- [ ] **Step 1: Stage the setlist in the provider**
+
+Add setlist state alongside the album draft. A setlist row is either an existing track (has `trackId`) or a pending new one (has a temp id + name):
+
+```tsx
+export type SetlistItem = { key: string; trackId: string | null; name: string };
+
+// inside the provider component:
+const [setlist, setSetlist] = useState<SetlistItem[]>(() =>
+  album.tracks.map((t) => ({ key: t.track_id, trackId: t.track_id, name: t.track_name }))
+);
+
+const moveItem = useCallback((index: number, delta: number) => {
+  setSetlist((list) => {
+    const next = list.slice();
+    const j = index + delta;
+    if (j < 0 || j >= next.length) return list;
+    [next[index], next[j]] = [next[j], next[index]];
+    return next;
+  });
+}, []);
+
+const removeItem = useCallback((key: string) => {
+  setSetlist((list) => list.filter((i) => i.key !== key));
+}, []);
+
+const addItem = useCallback((name: string) => {
+  const clean = name.trim();
+  if (!clean) return;
+  setSetlist((list) => [
+    ...list,
+    { key: `new-${list.length}-${clean}`, trackId: null, name: clean },
+  ]);
+}, []);
+```
+
+Include setlist in `dirty` (compare ordered keys + any pending/removed):
+
+```tsx
+const setlistDirty = useMemo(() => {
+  const now = setlist.map((i) => i.trackId ?? `+${i.name}`).join(",");
+  const orig = album.tracks.map((t) => t.track_id).join(",");
+  return now !== orig;
+}, [setlist, album.tracks]);
+// combine: const dirty = albumDirty || setlistDirty
+```
+
+Extend `save` to commit the setlist after the album fields (order matters — create/remove before reorder):
+
+```tsx
+// after updateAlbum / setAlbumGenres:
+const originalIds = new Set(album.tracks.map((t) => t.track_id));
+const keptIds = new Set(setlist.filter((i) => i.trackId).map((i) => i.trackId as string));
+
+// removed = original tracks no longer present
+for (const t of album.tracks) {
+  if (!keptIds.has(t.track_id)) await removeTrackFromAlbum(album.id, t.track_id);
+}
+// created = pending items; assign their new ids in place
+const created: Record<string, string> = {};
+for (const item of setlist) {
+  if (!item.trackId) created[item.key] = await createTrack(album.id, item.name);
+}
+// final order = each row's real id (existing or newly created)
+const orderedIds = setlist.map((i) => i.trackId ?? created[i.key]);
+await reorderSetlist(album.id, orderedIds);
+```
+
+After commit, a full data refresh is simplest for the setlist (new track ids, latest versions). Use `router.refresh()` from `next/navigation` instead of local mutation for this task:
+
+```tsx
+import { useRouter } from "next/navigation";
+// const router = useRouter();  // in the component
+// at the end of a successful save():
+setEditing(false);
+router.refresh();
+```
+
+Reset `setlist` when `album.tracks` changes (post-refresh) via an effect:
+
+```tsx
+useEffect(() => {
+  setSetlist(album.tracks.map((t) => ({ key: t.track_id, trackId: t.track_id, name: t.track_name })));
+}, [album.tracks]);
+```
+
+Expose `setlist`, `moveItem`, `removeItem`, `addItem` on the context value (add them to the type and the `useMemo`). Import `createTrack, removeTrackFromAlbum, reorderSetlist` from `@/lib/edit`.
+
+- [ ] **Step 2: Write the editable list**
+
+`src/components/edit/EditableSetlist.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ArrowUp, ArrowDown, X, Plus } from "lucide-react";
+import { useAlbumEdit } from "./AlbumEditProvider";
+import styles from "./EditableSetlist.module.css";
+
+export default function EditableSetlist() {
+  const { setlist, moveItem, removeItem, addItem } = useAlbumEdit();
+  const [name, setName] = useState("");
+
+  return (
+    <div className={styles.list}>
+      {setlist.map((item, i) => (
+        <div key={item.key} className={styles.row}>
+          <span className={styles.num}>{i + 1}</span>
+          <span className={styles.name}>
+            {item.name}
+            {!item.trackId && <em className={styles.pending}> · new</em>}
+          </span>
+          <div className={styles.controls}>
+            <button type="button" aria-label="Move up" disabled={i === 0}
+              onClick={() => moveItem(i, -1)}><ArrowUp size={16} /></button>
+            <button type="button" aria-label="Move down" disabled={i === setlist.length - 1}
+              onClick={() => moveItem(i, 1)}><ArrowDown size={16} /></button>
+            <button type="button" aria-label="Remove" className={styles.remove}
+              onClick={() => removeItem(item.key)}><X size={16} /></button>
+          </div>
+        </div>
+      ))}
+      <form
+        className={styles.add}
+        onSubmit={(e) => { e.preventDefault(); addItem(name); setName(""); }}
+      >
+        <input value={name} onChange={(e) => setName(e.target.value)}
+          placeholder="New track name…" aria-label="New track name" />
+        <button type="submit" disabled={!name.trim()}><Plus size={16} /> Add</button>
+      </form>
+      <p className={styles.hint}>Order &amp; track changes apply when you Save. Add audio to a track after saving.</p>
+    </div>
+  );
+}
+```
+
+`src/components/edit/EditableSetlist.module.css`:
+
+```css
+.list { display: flex; flex-direction: column; gap: 4px; }
+.row { display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+  border-radius: 6px; background: rgba(91,140,255,0.06); }
+.num { width: 18px; color: rgba(128,128,128,0.8); font-size: 13px; }
+.name { flex: 1; }
+.pending { color: #5b8cff; font-style: italic; font-size: 12px; }
+.controls { display: inline-flex; gap: 2px; }
+.controls button { background: none; border: none; cursor: pointer; color: inherit;
+  padding: 4px; display: inline-flex; border-radius: 4px; }
+.controls button:disabled { opacity: 0.3; cursor: default; }
+.remove { color: #e5484d; }
+.add { display: flex; gap: 6px; margin-top: 8px; }
+.add input { flex: 1; font: inherit; font-size: 13px; padding: 6px 8px; border-radius: 6px;
+  border: 1px solid rgba(128,128,128,0.35); background: transparent; color: inherit; }
+.add button { display: inline-flex; align-items: center; gap: 4px; font: inherit; font-size: 13px;
+  padding: 6px 10px; border-radius: 6px; border: 1px solid rgba(128,128,128,0.35);
+  background: rgba(128,128,128,0.08); color: inherit; cursor: pointer; }
+.hint { font-size: 12px; color: rgba(128,128,128,0.85); margin-top: 6px; }
+```
+
+- [ ] **Step 3: Swap the playlist in edit mode**
+
+In `AlbumDetailCard.tsx`, import `EditableSetlist` and branch the trailing playlist:
+
+```tsx
+import EditableSetlist from "./edit/EditableSetlist";
+// ...
+{editing ? (
+  <EditableSetlist />
+) : (
+  <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />
+)}
+```
+
+- [ ] **Step 4: Manual verification**
+
+Edit mode shows the setlist with ↑/↓/✕ per row and an **Add** field. Reorder two tracks, add a "new" row, remove one, then **Save** → page refreshes with the new order/membership persisted (verify by reloading). **Cancel** before saving discards all of it. Confirm the listener view (signed out) shows tracks in the saved order.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/edit/EditableSetlist.tsx src/components/edit/EditableSetlist.module.css src/components/edit/AlbumEditProvider.tsx src/components/AlbumDetailCard.tsx
+git commit -m "feat(ui): editable setlist — move/remove/add tracks, committed on save"
+```
+
+---
+
+## Task 7: Versions panel (list, add-with-upload, edit, delete)
+
+Per-track version management. These are **immediate** actions (not part of Save), and only appear for **persisted** tracks (a just-added track must be saved first so it has a real id). Rendered as an expandable panel under each track row in the editable setlist.
+
+**Files:**
+- Create: `src/components/edit/VersionsPanel.tsx`
+- Create: `src/components/edit/VersionsPanel.module.css`
+- Modify: `src/components/edit/EditableSetlist.tsx` (expand a row into the panel)
+
+- [ ] **Step 1: Write the panel**
+
+`src/components/edit/VersionsPanel.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Trash2, Upload } from "lucide-react";
+import type { AlbumVersion } from "@/lib/types";
+import {
+  listTrackVersions, createVersionWithFile, updateVersion, deleteVersion, VERSION_STATUSES,
+} from "@/lib/edit";
+import styles from "./VersionsPanel.module.css";
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function VersionsPanel({ trackId }: { trackId: string }) {
+  const [versions, setVersions] = useState<AlbumVersion[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState<string>("demo");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const reload = () =>
+    listTrackVersions(trackId).then(setVersions).catch((e) => console.error("load versions", e));
+
+  useEffect(() => { reload(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [trackId]);
+
+  async function onAdd() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) { alert("Pick an audio file first."); return; }
+    if (!name.trim()) { alert("Name the version first."); return; }
+    setBusy(true);
+    try {
+      await createVersionWithFile(trackId, name.trim(), status, today(), file);
+      setName("");
+      if (fileRef.current) fileRef.current.value = "";
+      await reload();
+    } catch (e) {
+      console.error("create version", e);
+      alert("Upload failed: " + (e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onStatusChange(v: AlbumVersion, next: string) {
+    setVersions((list) => list?.map((x) => (x.id === v.id ? { ...x, status: next } : x)) ?? null);
+    try {
+      await updateVersion(v.id, v.name, next, v.release_date);
+    } catch (e) {
+      console.error("update version", e);
+      await reload();
+    }
+  }
+
+  async function onDelete(v: AlbumVersion) {
+    if (!confirm(`Delete version “${v.name}”?`)) return;
+    try {
+      await deleteVersion(v.id);
+      await reload();
+    } catch (e) {
+      console.error("delete version", e);
+      alert("Delete failed: " + (e as Error).message);
+    }
+  }
+
+  return (
+    <div className={styles.panel}>
+      {versions === null ? (
+        <p className={styles.muted}>Loading versions…</p>
+      ) : versions.length === 0 ? (
+        <p className={styles.muted}>No versions yet.</p>
+      ) : (
+        <ul className={styles.versions}>
+          {versions.map((v) => (
+            <li key={v.id} className={styles.version}>
+              <span className={styles.vName}>{v.name}</span>
+              <select value={v.status} aria-label={`Status of ${v.name}`}
+                onChange={(e) => onStatusChange(v, e.target.value)}>
+                {VERSION_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+              <span className={styles.date}>{v.release_date}</span>
+              {v.resource_url ? <span className={styles.ok}>♪</span> : <span className={styles.muted}>no file</span>}
+              <button type="button" aria-label={`Delete ${v.name}`} className={styles.del}
+                onClick={() => onDelete(v)}><Trash2 size={15} /></button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className={styles.add}>
+        <input value={name} onChange={(e) => setName(e.target.value)}
+          placeholder="Version name…" aria-label="New version name" />
+        <select value={status} onChange={(e) => setStatus(e.target.value)} aria-label="New version status">
+          {VERSION_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <input ref={fileRef} type="file" accept="audio/*,.m4a" aria-label="Audio file" />
+        <button type="button" onClick={onAdd} disabled={busy}>
+          <Upload size={15} /> {busy ? "Uploading…" : "Add version"}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+`src/components/edit/VersionsPanel.module.css`:
+
+```css
+.panel { padding: 8px 10px; margin: 2px 0 6px 26px; border-left: 2px solid rgba(91,140,255,0.3); }
+.muted { color: rgba(128,128,128,0.85); font-size: 12px; }
+.versions { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.version { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.vName { flex: 1; }
+.date { color: rgba(128,128,128,0.8); font-size: 12px; }
+.ok { color: #30a46c; }
+.del { background: none; border: none; color: #e5484d; cursor: pointer; display: inline-flex; }
+.add { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.add input[type="text"], .add input:not([type]), .add select { font: inherit; font-size: 13px;
+  padding: 5px 7px; border-radius: 6px; border: 1px solid rgba(128,128,128,0.35);
+  background: transparent; color: inherit; }
+.add button { display: inline-flex; align-items: center; gap: 4px; font: inherit; font-size: 13px;
+  padding: 5px 10px; border-radius: 6px; border: 1px solid #5b8cff; background: #5b8cff; color: #fff; cursor: pointer; }
+.add button:disabled { opacity: 0.6; cursor: default; }
+```
+
+- [ ] **Step 2: Expand rows into the panel**
+
+In `EditableSetlist.tsx`, add a per-row expand toggle that renders `VersionsPanel` for persisted tracks only. Add state and a button:
+
+```tsx
+import { ChevronDown, ChevronRight } from "lucide-react";
+import VersionsPanel from "./VersionsPanel";
+// ...
+const [openKey, setOpenKey] = useState<string | null>(null);
+// inside the row, before the controls:
+<button type="button" aria-label="Toggle versions" className={styles.expand}
+  disabled={!item.trackId}
+  onClick={() => setOpenKey((k) => (k === item.key ? null : item.key))}>
+  {openKey === item.key ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+</button>
+// after the row's closing </div>, still inside the map:
+{openKey === item.key && item.trackId && <VersionsPanel trackId={item.trackId} />}
+```
+
+Add a `.expand` style mirroring `.controls button` (disabled when the track isn't saved yet):
+
+```css
+.expand { background: none; border: none; cursor: pointer; color: inherit; padding: 4px;
+  display: inline-flex; border-radius: 4px; }
+.expand:disabled { opacity: 0.3; cursor: default; }
+```
+
+- [ ] **Step 3: Manual verification**
+
+In edit mode, expand a saved track → its versions list loads. **Add version**: name it, pick a status, choose an `.m4a`, click **Add version** → it uploads to the `versions` bucket, links via `create_version`, and appears in the list with a ♪ (file present). Reload the album (listener view) → the track is playable / the latest version reflects. Change a version's status (persists immediately). Delete a version (confirms, then removed). Confirm a **newly-added, not-yet-saved** track shows a disabled expand (must Save first).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/edit/VersionsPanel.tsx src/components/edit/VersionsPanel.module.css src/components/edit/EditableSetlist.tsx src/components/edit/EditableSetlist.module.css
+git commit -m "feat(ui): per-track versions panel with audio upload"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec §8 coverage:** member-gated edit toggle (T3), contenteditable name/description (T3), type select (T3), genre chip combobox (T4), click-to-replace cover (T5), setlist move/remove/add (T6), per-track versions + upload (T7), explicit Save/Cancel with staged album+setlist and immediate file ops (T3/T6/T7). `canEdit` is computed client-side from `artist_members` (cache-safe), and every write is additionally guarded server-side by the Plan 1 RPCs.
+- **Deferred / out of scope (as agreed):** creating a brand-new album from zero; per-track cover editing; Works/variants; tightened per-artist storage policies.
+- **Known simplifications to revisit:** save errors use `alert()` (fine for a solo tool; swap for a toast later); the setlist commit is sequential RPC calls (not a single transaction) — acceptable because each RPC is atomic and a partial failure is recoverable by re-saving; deleting a version leaves its audio object in the `versions` bucket (storage GC is a deferred follow-up from Plan 1).
+- **Dependency note:** no new packages — reorder uses up/down controls per your choice.
+- **After Task 7:** run `npx tsc --noEmit` to confirm the whole edit surface type-checks before finishing the branch.

--- a/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
+++ b/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
@@ -990,7 +990,7 @@ git commit -m "feat(ui): genre chip combobox with create, saved with the album"
 ```tsx
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, type CSSProperties } from "react";
 import { Upload } from "lucide-react";
 import AlbumCover from "../AlbumCover";
 import { uploadAlbumCover } from "@/lib/edit";
@@ -1026,7 +1026,7 @@ export default function CoverUploader({
   }
 
   return (
-    <div className={styles.wrap}>
+    <div className={styles.wrap} style={{ "--size": `${size}px` } as CSSProperties}>
       <AlbumCover coverUrl={url} alt={alt} size={size} priority />
       <button
         type="button"
@@ -1054,11 +1054,13 @@ export default function CoverUploader({
 
 ```css
 .wrap { position: relative; display: inline-block; }
-.overlay { position: absolute; inset: 0; display: flex; flex-direction: column;
-  align-items: center; justify-content: center; gap: 4px; border: none; cursor: pointer;
-  border-radius: 8px; color: #fff; font: inherit; font-size: 12px;
-  background: rgba(0,0,0,0.45); opacity: 0; transition: opacity 0.15s; }
-.wrap:hover .overlay, .overlay:focus-visible { opacity: 1; }
+.overlay { position: absolute; top: 0; left: 0; width: var(--size); height: var(--size);
+  z-index: 2; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px; border: none; cursor: pointer;
+  border-radius: calc(var(--size)*0.05) calc(var(--size)*0.1) calc(var(--size)*0.1) calc(var(--size)*0.05);
+  color: #fff; font: inherit; font-size: 12px; background: rgba(0,0,0,0.45);
+  opacity: 0; transition: opacity 0.15s; }
+.overlay:hover, .overlay:focus-visible { opacity: 1; }
 .overlay:disabled { opacity: 1; cursor: default; }
 ```
 

--- a/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
+++ b/docs/superpowers/plans/2026-07-12-inline-edit-ui.md
@@ -337,7 +337,10 @@ export async function createVersionWithFile(
     _release_date: releaseDate,
   });
   if (error) throw new Error(error.message);
-  const { version_id, upload_path } = data as { version_id: string; upload_path: string };
+  // create_version RETURNS TABLE(...) → PostgREST returns an array of rows.
+  const row = (data as { version_id: string; upload_path: string }[])[0];
+  if (!row) throw new Error("create_version returned no row");
+  const { version_id, upload_path } = row;
 
   const up = await supabase.storage.from("versions").upload(upload_path, file, { upsert: true });
   if (up.error) throw new Error(up.error.message);

--- a/docs/superpowers/specs/2026-07-12-artist-content-management-design.md
+++ b/docs/superpowers/specs/2026-07-12-artist-content-management-design.md
@@ -1,0 +1,284 @@
+# Artist Content Management — Design Spec
+
+**Date:** 2026-07-12
+**Status:** Approved design → ready for implementation planning
+**Author:** Alexis (with Claude)
+
+## 1. Problem
+
+Publishing a song today is a painful, multi-step manual process in the Supabase
+dashboard: create a `tracks` row, create the `album_tracks` join, create a
+`versions` row, create the track's folder in the `songs` bucket following
+`{track.slug}-{track.id}`, upload the file as `{track.slug}-{version.id}.m4a`,
+copy the file's URL, and paste it back into the `versions.resource_url` column.
+
+We want an in-app interface that lets an artist CRUD albums (with cover upload),
+tracks, and versions (with file upload), and manage an album's setlist and its
+order — with a permissions layer so access is scoped to the artist.
+
+## 2. Goals & scope
+
+**In scope (this build):**
+
+- **Model:** an `artist_members` roles layer (`owner` / `maintainer`); link
+  albums to artists; add setlist ordering; add a genre vocabulary.
+- **API/RPC:** `SECURITY DEFINER` Postgres functions for all album/track/version
+  CRUD + setlist reorder, each enforcing artist membership internally.
+- **Storage:** direct-to-bucket uploads for audio and covers, authorized by
+  Storage RLS; `resource_url` / `cover_url` written by RPC, never by hand.
+- **UI:** inline (WYSIWYG) edit mode on the existing album page, gated to members.
+
+**Out of scope (explicitly deferred):**
+
+- The **Work / variant** model (acoustic / live / remix / orchestral, covers,
+  remixes, cross-artist authorship). Nothing here blocks it; see §11.
+- The track page that browses work-in-progress versions.
+- Self-serve artist onboarding — artists and memberships are seeded **manually in
+  Supabase** for now. Opening the platform comes later.
+- A maintainer-management UI (owner adding/removing members). Roles are assigned
+  by hand in Supabase this build.
+- Comments / reactions UI (those tables exist but are unrelated to this work).
+- Tightened per-artist Storage policies (see §7 — a coarse policy ships now).
+
+## 3. Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Roles model | `artists` (exists) + `artist_members(artist_id, user_id, role)` junction | Clean owner/maintainer, scales to opening up |
+| Write architecture | `SECURITY DEFINER` RPCs + direct Storage uploads | Cross-platform contract (web/iOS/Android call identically); **no service-role key needed** — every write authorized by the caller's session |
+| Audio/cover URL | Keep `resource_url` / `cover_url`, **machine-written** by RPC from the deterministic path | Never paste by hand; retains an escape hatch for external URLs |
+| Genre | `genres` + `album_genres` many-to-many | Controlled, searchable combobox; multi-select chips |
+| Slug | Existing generated 3-char column; `id` disambiguates the path | Not user-editable by construction; renames don't break stored URLs |
+| `version_status` | Cosmetic production tag (`raw, draft, demo, prototype, final`) | **No visibility gating** — public read unchanged |
+| Track ↔ version link | **`track_versions` junction is canonical** | The `track_overview` view reads through it; also the future variant seam |
+| Edit UX | Inline edit mode on the album page | Modern/WYSIWYG; fits the single-artist "make it feel real" phase |
+
+## 4. Current schema (relevant existing tables)
+
+Confirmed from the live database (2026-07-12):
+
+- `artists(id, name, slug*, created_at)` — **already exists**. `slug*` is a
+  generated column: `lower(substring(regexp_replace(name,'[^A-Za-z0-9]','','g') from 1 for 3))`.
+- `albums(id, type <enum>, name, description, cover_url, created_at)` — **no
+  `artist_id` yet**. `type` is a Postgres enum (values read at implementation time).
+- `tracks(id, name, slug*, description, lyrics, cover_url, created_at)` — has its
+  own `cover_url`. `slug*` generated as above.
+- `versions(id, name, status <version_status>, resource_url, release_date, description, track_id → tracks, created_at)`.
+  `version_status` enum = `raw, draft, demo, prototype, final`. **`versions` has no
+  `slug` column by design** — the storage path inherits the *track's* slug, so the
+  file is named `{track.slug}-{version.id}.m4a` (the version contributes only its id).
+- `track_versions(track_id → tracks, version_id → versions, created_at, pk(track_id, version_id))`
+  — **canonical** track↔version link (used by `track_overview`).
+- `album_tracks(id bigint identity, album_id → albums, track_id → tracks, created_at)`
+  — **no position column yet**.
+- `track_like_counts`, `track_likes`, `reactions`, `reaction_clicks`, `threads`,
+  `comments`, `track_plays`, `rights` — present, out of scope here.
+- `track_overview` view: computes `latest_*` per track via
+  `track_versions → versions` ordered by `release_date desc, created_at desc`;
+  "primary album" = most-recently-linked `album_tracks` (by `created_at desc`);
+  `like_count` from `track_like_counts`.
+
+RLS is **enabled** on all core tables (`tracks, artists, versions, albums,
+album_tracks, track_versions`), with permissive public SELECT (the anon client
+reads them).
+
+## 5. Schema changes
+
+### 5.1 New tables
+
+```sql
+-- Roles layer: which users can manage which artist.
+create table public.artist_members (
+  artist_id  uuid not null references public.artists(id) on delete cascade,
+  user_id    uuid not null references auth.users(id)     on delete cascade,
+  role       text not null check (role in ('owner','maintainer')),
+  created_at timestamptz not null default now(),
+  primary key (artist_id, user_id)
+);
+
+-- Controlled genre vocabulary (searchable combobox source).
+create table public.genres (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null unique,
+  slug       text not null,           -- proper slug of name (see §5.4)
+  created_at timestamptz not null default now()
+);
+
+-- Albums ↔ genres (many-to-many).
+create table public.album_genres (
+  album_id uuid not null references public.albums(id)  on delete cascade,
+  genre_id uuid not null references public.genres(id)  on delete cascade,
+  primary key (album_id, genre_id)
+);
+```
+
+### 5.2 Alters
+
+```sql
+-- Link albums to their artist (backfill = the seeded bohns artist).
+alter table public.albums add column artist_id uuid references public.artists(id);
+
+-- Setlist ordering within an album.
+alter table public.album_tracks add column position int;
+-- Backfill: per album, number existing links by created_at.
+```
+
+No column is added to `versions`: the audio file inherits the track's slug (see §5.4).
+
+`track_overview` and app queries switch to ordering an album's tracks by
+`album_tracks.position` (primary-album selection and latest-version logic are
+unchanged).
+
+### 5.3 RLS / lockdown
+
+- **Keep** the existing permissive public SELECT on all content tables and on the
+  new `artists`, `genres`, `album_genres`.
+- **Ensure no client write policies exist** on
+  `albums, tracks, versions, album_tracks, track_versions, album_genres` — writes
+  flow exclusively through `SECURITY DEFINER` RPCs (which bypass RLS as the
+  function owner). Enable RLS on the three new tables.
+- `artist_members`: RLS on; a member may SELECT rows for artists they belong to;
+  **no client writes** (seeded in Supabase this build).
+
+### 5.4 Slug note
+
+Existing `tracks`/`artists` slugs are a generated 3-char prefix; the `id` in the
+storage path guarantees uniqueness, so collisions are irrelevant. **`versions` have
+no slug of their own** — the audio path reuses the *track's* slug plus the version
+`id`. `genres` uses a proper full slug of `name` (it appears in filters/URLs, not
+storage paths).
+
+## 6. RPC surface (the "API")
+
+All functions are `SECURITY DEFINER`, `search_path` pinned, and call the
+membership guard **first**. They are the single write contract for every client.
+
+```sql
+-- Guard: is the current user a member of this artist?
+create function public.is_artist_member(_artist_id uuid) returns boolean
+  language sql security definer stable as $$
+  select exists (
+    select 1 from public.artist_members m
+    where m.artist_id = _artist_id and m.user_id = auth.uid()
+  );
+$$;
+```
+
+**Albums**
+- `create_album(_artist_id, _name, _type, _description, _genre_ids uuid[]) → albums`
+  — guard `_artist_id`; insert album; insert `album_genres`.
+- `update_album(_album_id, _name, _description, _type)` — guard via the album's artist.
+- `delete_album(_album_id)`.
+- `set_album_genres(_album_id, _genre_ids uuid[])` — replace the album's genre set.
+- `set_album_cover(_album_id, _path text)` — after the client uploads the cover,
+  validate and write `cover_url` = public URL for `_path` (cover extension varies,
+  so the path is passed in and validated).
+
+**Tracks**
+- `create_track(_album_id, _name, _description, _lyrics) → tracks`
+  — guard via album's artist; insert track; insert `album_tracks` at
+  `position = max(position)+1`. Replaces the manual track→join dance.
+- `update_track(_track_id, _name, _description, _lyrics)`.
+- `remove_track_from_album(_album_id, _track_id)` — unlink only (a track may sit on
+  multiple albums).
+- `delete_track(_track_id)` — remove `album_tracks` links, `track_versions` links,
+  and now-orphaned `versions` rows (their files cleaned up client-side; see §7).
+- `reorder_setlist(_album_id, _ordered_track_ids uuid[])` — set `position` per the
+  array order in one atomic call.
+
+**Versions**
+- `create_version(_track_id, _name, _status, _release_date) → (version_id uuid, upload_path text)`
+  — guard via the track's artist; insert `versions` (with `track_id` kept in sync)
+  and a `track_versions` link; compute and return
+  `upload_path = {track.slug}-{track.id}/{track.slug}-{version.id}.m4a`
+  (the file reuses the track's slug; the version contributes only its `id`).
+- `set_version_file(_version_id)` — after upload, **recompute** the deterministic
+  path and write `resource_url` = its public URL (no client-supplied path — fully
+  machine-written).
+- `update_version(_version_id, _name, _status, _release_date)`.
+- `delete_version(_version_id)` — remove `track_versions` link(s) + the `versions`
+  row (file cleaned up client-side).
+
+**Genres**
+- `create_genre(_name) → genres` — any authenticated `artist_member` may extend the
+  vocabulary. Listing genres is a plain public SELECT (no RPC).
+
+Each RPC is atomic and self-authorizing: one round trip replaces the entire
+create-track → join → version → path → paste chain.
+
+## 7. Storage
+
+- **`songs`** bucket (exists, public): audio at
+  `{track.slug}-{track.id}/{track.slug}-{version.id}.m4a`.
+- **Covers:** confirm whether a bucket exists (`select id,name from storage.buckets`);
+  if not, create a public `covers` bucket. Cover path e.g. `{album.slug}-{album.id}.<ext>`.
+- **Chicken/egg solved:** the row is created first (`create_version` returns the
+  id and path), *then* the client uploads to the now-known path, *then*
+  `set_version_file` writes the URL.
+- **Storage RLS (coarse, this build):** on `storage.objects` for `songs`/`covers`,
+  INSERT/UPDATE/DELETE require the caller to be an `artist_member` of **any**
+  artist; SELECT stays public. **Known simplification** — tighten to per-artist
+  path parsing when the platform opens up.
+- **File deletion on row delete** is done client-side via the Storage SDK
+  (Postgres can't cleanly delete storage objects). Orphan-cleanup automation is a
+  follow-up, not this build.
+
+## 8. Inline edit UI
+
+- **Gating:** the album page (server component) checks whether the current user is
+  an `artist_member` of the album's artist and passes a `canEdit` prop. The Edit
+  toggle renders only when `canEdit`.
+- **`EditProvider`** (client context) flips existing components
+  (`AlbumDetailCard`, `AlbumHeader`, `AlbumPlaylist`, `AlbumTrack`) into editable
+  variants. The listener render path is untouched when not editing.
+  - Name / description → `contenteditable`.
+  - Cover → click-to-replace (upload → `set_album_cover`).
+  - Genres → chip multi-select combobox reading from `genres` (search); commits via
+    `set_album_genres`.
+  - Track rows → drag-reorder (`reorder_setlist`), remove
+    (`remove_track_from_album`), add-track (`create_track`).
+  - Versions (the fiddly part) → a per-track expandable panel with a dropzone +
+    progress: `create_version` → upload → `set_version_file`.
+- **Persistence — explicit Save / Cancel.** Entering edit mode stages changes in
+  local client state; a single **Save** commits the batch and **Cancel** discards
+  it. Save persists album fields, the genre set, track-list membership, setlist
+  order, and track metadata via the RPCs, called through the authenticated browser
+  Supabase client (the session authorizes them via the membership guard + Storage
+  RLS). **No service-role key anywhere.**
+- **File uploads are immediate, discrete actions — not part of the Save batch.** A
+  binary can't sit comfortably in staged form state, and `create_version` must
+  insert the row before the upload path exists. So the per-track Versions panel
+  treats *create version → upload → finalize*, *replace file*, and *delete version*
+  as their own confirmed operations with progress; cover replacement likewise
+  uploads on pick. Metadata around them (status, name, release date) still saves
+  with the batch.
+
+## 9. Access seeding (manual, documented)
+
+In the Supabase SQL editor:
+
+```sql
+-- Assign yourself as owner of the bohns artist.
+insert into public.artist_members (artist_id, user_id, role)
+values ('<bohns_artist_id>', '<your_auth_user_id>', 'owner');
+```
+
+The migration also backfills `albums.artist_id` to the bohns artist.
+
+## 10. Open items (resolved at implementation, non-blocking)
+
+- Read the `albums.type` enum values for the type `<select>` in the edit UI.
+- Confirm the `covers` bucket exists; create it (public) if absent.
+- Verify/remove any stray client write policies on the content tables (§5.3).
+
+## 11. Forward-compatibility (deferred work this design must not block)
+
+- **Works / variants:** the `track_versions` junction already lets a recording
+  attach to multiple tracks — the seam the variant model grows from. Future
+  additive changes: a `works` concept (relational or entity — TBD), plus track-level
+  `variant_type` / `relation` / performer-artist attributes. None conflict with
+  this build.
+- **Per-track covers** (`tracks.cover_url`) can become editable with a small
+  addition; album cover ships first.
+- **Maintainer management, self-serve onboarding, tightened Storage policies** —
+  additive, on top of the roles layer defined here.

--- a/src/app/albums/[id]/page.tsx
+++ b/src/app/albums/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Header from "@/components/Header";
 import AlbumSwitcher from "@/components/AlbumSwitcher";
 import AlbumDetailCard from "@/components/AlbumDetailCard";
-import { getAlbumsWithTracks, getLyrics } from "@/lib/data";
+import { getAlbumsWithTracks, getAlbumWithTracks, getLyrics } from "@/lib/data";
 import styles from "./page.module.css";
 
 export const revalidate = 300;
@@ -22,8 +22,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function AlbumPage({ params }: Props) {
   const { id } = await params;
 
-  const albums = await getAlbumsWithTracks();
-  const album = albums.find((a) => a.id === id);
+  const [albums, album] = await Promise.all([
+    getAlbumsWithTracks(),
+    getAlbumWithTracks(id),
+  ]);
   if (!album) notFound();
 
   const lyrics = await getLyrics(album.tracks.map((t) => t.track_id));

--- a/src/app/albums/[id]/page.tsx
+++ b/src/app/albums/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import Header from "@/components/Header";
 import AlbumSwitcher from "@/components/AlbumSwitcher";
 import AlbumDetailCard from "@/components/AlbumDetailCard";
+import { AlbumEditProvider } from "@/components/edit/AlbumEditProvider";
 import { getAlbumsWithTracks, getAlbumWithTracks, getLyrics } from "@/lib/data";
 import styles from "./page.module.css";
 
@@ -35,7 +36,9 @@ export default async function AlbumPage({ params }: Props) {
       <Header variant="compact" />
       <div className={styles.content}>
         <AlbumSwitcher albums={albums} activeId={album.id} />
-        <AlbumDetailCard album={album} lyrics={lyrics} />
+        <AlbumEditProvider album={album}>
+          <AlbumDetailCard album={album} lyrics={lyrics} />
+        </AlbumEditProvider>
       </div>
     </div>
   );

--- a/src/components/AlbumDetailCard.module.css
+++ b/src/components/AlbumDetailCard.module.css
@@ -24,6 +24,23 @@
   line-height: 22px;
 }
 
+.editBar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nameEdit {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
 @media (max-width: 767px) {
   .hero {
     flex-direction: column;

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -11,6 +11,7 @@ import EditToggle from "./edit/EditToggle";
 import EditableText from "./edit/EditableText";
 import AlbumTypeSelect from "./edit/AlbumTypeSelect";
 import GenrePicker from "./edit/GenrePicker";
+import CoverUploader from "./edit/CoverUploader";
 import { useAlbumEdit } from "./edit/AlbumEditProvider";
 import styles from "./AlbumDetailCard.module.css";
 
@@ -30,12 +31,21 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
         <EditToggle />
       </div>
       <div className={styles.hero}>
-        <AlbumCover
-          coverUrl={album.cover_url}
-          alt={album.name}
-          size={165}
-          priority
-        />
+        {editing ? (
+          <CoverUploader
+            albumId={album.id}
+            coverUrl={album.cover_url}
+            alt={album.name}
+            size={165}
+          />
+        ) : (
+          <AlbumCover
+            coverUrl={album.cover_url}
+            alt={album.name}
+            size={165}
+            priority
+          />
+        )}
         <div className={styles.heroBody}>
           {editing ? (
             <div className={styles.header}>

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -10,6 +10,7 @@ import AlbumPlaylist from "./AlbumPlaylist";
 import EditToggle from "./edit/EditToggle";
 import EditableText from "./edit/EditableText";
 import AlbumTypeSelect from "./edit/AlbumTypeSelect";
+import GenrePicker from "./edit/GenrePicker";
 import { useAlbumEdit } from "./edit/AlbumEditProvider";
 import styles from "./AlbumDetailCard.module.css";
 
@@ -66,10 +67,16 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
           )}
 
           {editing ? (
-            <AlbumTypeSelect
-              value={draft.type}
-              onChange={(v) => setField("type", v)}
-            />
+            <>
+              <AlbumTypeSelect
+                value={draft.type}
+                onChange={(v) => setField("type", v)}
+              />
+              <GenrePicker
+                selected={draft.genres}
+                onChange={(g) => setField("genres", g)}
+              />
+            </>
           ) : (
             <AlbumMetaTiles
               genre={palette.genre ?? capitalize(album.type)}

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -12,6 +12,7 @@ import EditableText from "./edit/EditableText";
 import AlbumTypeSelect from "./edit/AlbumTypeSelect";
 import GenrePicker from "./edit/GenrePicker";
 import CoverUploader from "./edit/CoverUploader";
+import EditableSetlist from "./edit/EditableSetlist";
 import { useAlbumEdit } from "./edit/AlbumEditProvider";
 import styles from "./AlbumDetailCard.module.css";
 
@@ -96,7 +97,11 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
           )}
         </div>
       </div>
-      <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />
+      {editing ? (
+        <EditableSetlist />
+      ) : (
+        <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />
+      )}
     </article>
   );
 }

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -1,9 +1,16 @@
+"use client";
+
 import type { AlbumWithTracks, TrackLyrics } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
 import AlbumCover from "./AlbumCover";
 import AlbumHeader from "./AlbumHeader";
+import AlbumInfos from "./AlbumInfos";
 import AlbumMetaTiles from "./AlbumMetaTiles";
 import AlbumPlaylist from "./AlbumPlaylist";
+import EditToggle from "./edit/EditToggle";
+import EditableText from "./edit/EditableText";
+import AlbumTypeSelect from "./edit/AlbumTypeSelect";
+import { useAlbumEdit } from "./edit/AlbumEditProvider";
 import styles from "./AlbumDetailCard.module.css";
 
 type Props = {
@@ -13,10 +20,14 @@ type Props = {
 
 /** Album page main card (Figma "AlbumCard" on Album frames). */
 export default function AlbumDetailCard({ album, lyrics }: Props) {
+  const { editing, draft, setField } = useAlbumEdit();
   const palette = getPalette(album);
 
   return (
     <article className={styles.card} style={paletteVars(palette)}>
+      <div className={styles.editBar}>
+        <EditToggle />
+      </div>
       <div className={styles.hero}>
         <AlbumCover
           coverUrl={album.cover_url}
@@ -25,15 +36,47 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
           priority
         />
         <div className={styles.heroBody}>
-          <AlbumHeader album={album} />
-          {album.description && (
-            <p className={styles.description}>{album.description}</p>
+          {editing ? (
+            <div className={styles.header}>
+              <EditableText
+                ariaLabel="Album name"
+                value={draft.name}
+                onCommit={(v) => setField("name", v)}
+                className={styles.nameEdit}
+              />
+              <AlbumInfos tracks={album.tracks} />
+            </div>
+          ) : (
+            <AlbumHeader album={album} />
           )}
-          <AlbumMetaTiles
-            genre={palette.genre ?? capitalize(album.type)}
-            year={new Date(album.created_at).getFullYear().toString()}
-            direction="horizontal"
-          />
+
+          {editing ? (
+            <EditableText
+              ariaLabel="Album description"
+              multiline
+              value={draft.description}
+              placeholder="Add a description…"
+              onCommit={(v) => setField("description", v)}
+              className={styles.description}
+            />
+          ) : (
+            album.description && (
+              <p className={styles.description}>{album.description}</p>
+            )
+          )}
+
+          {editing ? (
+            <AlbumTypeSelect
+              value={draft.type}
+              onChange={(v) => setField("type", v)}
+            />
+          ) : (
+            <AlbumMetaTiles
+              genre={palette.genre ?? capitalize(album.type)}
+              year={new Date(album.created_at).getFullYear().toString()}
+              direction="horizontal"
+            />
+          )}
         </div>
       </div>
       <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />

--- a/src/components/edit/AlbumEditProvider.tsx
+++ b/src/components/edit/AlbumEditProvider.tsx
@@ -8,8 +8,16 @@ import {
   useMemo,
   useState,
 } from "react";
+import { useRouter } from "next/navigation";
 import type { AlbumWithTracks, Genre } from "@/lib/types";
-import { getMyArtistIds, setAlbumGenres, updateAlbum } from "@/lib/edit";
+import {
+  createTrack,
+  getMyArtistIds,
+  removeTrackFromAlbum,
+  reorderSetlist,
+  setAlbumGenres,
+  updateAlbum,
+} from "@/lib/edit";
 
 type Draft = {
   name: string;
@@ -18,16 +26,22 @@ type Draft = {
   genres: Genre[];
 };
 
+export type SetlistItem = { key: string; trackId: string | null; name: string };
+
 type EditContextValue = {
   canEdit: boolean;
   editing: boolean;
   saving: boolean;
   dirty: boolean;
   draft: Draft;
+  setlist: SetlistItem[];
   startEditing: () => void;
   cancel: () => void;
   save: () => Promise<void>;
   setField: <K extends keyof Draft>(key: K, value: Draft[K]) => void;
+  moveItem: (index: number, delta: number) => void;
+  removeItem: (key: string) => void;
+  addItem: (name: string) => void;
   album: AlbumWithTracks;
 };
 
@@ -48,6 +62,14 @@ function draftFrom(album: AlbumWithTracks): Draft {
   };
 }
 
+function setlistFrom(album: AlbumWithTracks): SetlistItem[] {
+  return album.tracks.map((t) => ({
+    key: t.track_id,
+    trackId: t.track_id,
+    name: t.track_name,
+  }));
+}
+
 export function AlbumEditProvider({
   album,
   children,
@@ -55,10 +77,12 @@ export function AlbumEditProvider({
   album: AlbumWithTracks;
   children: React.ReactNode;
 }) {
+  const router = useRouter();
   const [canEdit, setCanEdit] = useState(false);
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [draft, setDraft] = useState<Draft>(() => draftFrom(album));
+  const [setlist, setSetlist] = useState<SetlistItem[]>(() => setlistFrom(album));
 
   useEffect(() => {
     let active = true;
@@ -74,7 +98,12 @@ export function AlbumEditProvider({
     };
   }, [album.artist_id]);
 
-  const dirty = useMemo(() => {
+  // Re-sync the staged setlist after the server data changes (e.g. router.refresh()).
+  useEffect(() => {
+    setSetlist(setlistFrom(album));
+  }, [album.tracks]);
+
+  const albumDirty = useMemo(() => {
     const a = draft.genres.map((g) => g.id).slice().sort().join(",");
     const b = album.genres.map((g) => g.id).slice().sort().join(",");
     return (
@@ -85,10 +114,19 @@ export function AlbumEditProvider({
     );
   }, [draft, album]);
 
+  const setlistDirty = useMemo(() => {
+    const now = setlist.map((i) => i.trackId ?? `+${i.name}`).join(",");
+    const orig = album.tracks.map((t) => t.track_id).join(",");
+    return now !== orig;
+  }, [setlist, album.tracks]);
+
+  const dirty = albumDirty || setlistDirty;
+
   const startEditing = useCallback(() => setEditing(true), []);
 
   const cancel = useCallback(() => {
     setDraft(draftFrom(album));
+    setSetlist(setlistFrom(album));
     setEditing(false);
   }, [album]);
 
@@ -98,26 +136,59 @@ export function AlbumEditProvider({
     []
   );
 
+  const moveItem = useCallback((index: number, delta: number) => {
+    setSetlist((list) => {
+      const next = list.slice();
+      const j = index + delta;
+      if (j < 0 || j >= next.length) return list;
+      [next[index], next[j]] = [next[j], next[index]];
+      return next;
+    });
+  }, []);
+
+  const removeItem = useCallback((key: string) => {
+    setSetlist((list) => list.filter((i) => i.key !== key));
+  }, []);
+
+  const addItem = useCallback((name: string) => {
+    const clean = name.trim();
+    if (!clean) return;
+    setSetlist((list) => [
+      ...list,
+      { key: `new-${list.length}-${clean}`, trackId: null, name: clean },
+    ]);
+  }, []);
+
   const save = useCallback(async () => {
     setSaving(true);
     try {
-      if (dirty) {
+      if (albumDirty) {
         await updateAlbum(album.id, draft.name, draft.description || null, draft.type);
         await setAlbumGenres(album.id, draft.genres.map((g) => g.id));
       }
+      if (setlistDirty) {
+        const keptIds = new Set(
+          setlist.filter((i) => i.trackId).map((i) => i.trackId as string)
+        );
+        for (const t of album.tracks) {
+          if (!keptIds.has(t.track_id)) await removeTrackFromAlbum(album.id, t.track_id);
+        }
+        const created: Record<string, string> = {};
+        for (const item of setlist) {
+          if (!item.trackId) created[item.key] = await createTrack(album.id, item.name);
+        }
+        const orderedIds = setlist.map((i) => i.trackId ?? created[i.key]);
+        if (orderedIds.length) await reorderSetlist(album.id, orderedIds);
+      }
       setEditing(false);
-      // Reflect the saved values without a full reload.
-      album.name = draft.name;
-      album.description = draft.description || null;
-      album.type = draft.type;
-      album.genres = draft.genres;
+      router.refresh();
     } catch (err) {
       console.error("Save failed", err);
       alert("Save failed: " + (err as Error).message);
     } finally {
       setSaving(false);
     }
-  }, [album, draft, dirty]);
+  }, [album, draft, albumDirty, setlist, setlistDirty, router]);
 
   const value = useMemo<EditContextValue>(
     () => ({
@@ -126,13 +197,20 @@ export function AlbumEditProvider({
       saving,
       dirty,
       draft,
+      setlist,
       startEditing,
       cancel,
       save,
       setField,
+      moveItem,
+      removeItem,
+      addItem,
       album,
     }),
-    [canEdit, editing, saving, dirty, draft, startEditing, cancel, save, setField, album]
+    [
+      canEdit, editing, saving, dirty, draft, setlist,
+      startEditing, cancel, save, setField, moveItem, removeItem, addItem, album,
+    ]
   );
 
   return <EditContext.Provider value={value}>{children}</EditContext.Provider>;

--- a/src/components/edit/AlbumEditProvider.tsx
+++ b/src/components/edit/AlbumEditProvider.tsx
@@ -8,10 +8,15 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { AlbumWithTracks } from "@/lib/types";
-import { getMyArtistIds, updateAlbum } from "@/lib/edit";
+import type { AlbumWithTracks, Genre } from "@/lib/types";
+import { getMyArtistIds, setAlbumGenres, updateAlbum } from "@/lib/edit";
 
-type Draft = { name: string; description: string; type: string };
+type Draft = {
+  name: string;
+  description: string;
+  type: string;
+  genres: Genre[];
+};
 
 type EditContextValue = {
   canEdit: boolean;
@@ -39,6 +44,7 @@ function draftFrom(album: AlbumWithTracks): Draft {
     name: album.name,
     description: album.description ?? "",
     type: album.type ?? "album",
+    genres: album.genres,
   };
 }
 
@@ -68,13 +74,16 @@ export function AlbumEditProvider({
     };
   }, [album.artist_id]);
 
-  const dirty = useMemo(
-    () =>
+  const dirty = useMemo(() => {
+    const a = draft.genres.map((g) => g.id).slice().sort().join(",");
+    const b = album.genres.map((g) => g.id).slice().sort().join(",");
+    return (
       draft.name !== album.name ||
       draft.description !== (album.description ?? "") ||
-      draft.type !== (album.type ?? "album"),
-    [draft, album]
-  );
+      draft.type !== (album.type ?? "album") ||
+      a !== b
+    );
+  }, [draft, album]);
 
   const startEditing = useCallback(() => setEditing(true), []);
 
@@ -94,12 +103,14 @@ export function AlbumEditProvider({
     try {
       if (dirty) {
         await updateAlbum(album.id, draft.name, draft.description || null, draft.type);
+        await setAlbumGenres(album.id, draft.genres.map((g) => g.id));
       }
       setEditing(false);
       // Reflect the saved values without a full reload.
       album.name = draft.name;
       album.description = draft.description || null;
       album.type = draft.type;
+      album.genres = draft.genres;
     } catch (err) {
       console.error("Save failed", err);
       alert("Save failed: " + (err as Error).message);

--- a/src/components/edit/AlbumEditProvider.tsx
+++ b/src/components/edit/AlbumEditProvider.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { AlbumWithTracks } from "@/lib/types";
+import { getMyArtistIds, updateAlbum } from "@/lib/edit";
+
+type Draft = { name: string; description: string; type: string };
+
+type EditContextValue = {
+  canEdit: boolean;
+  editing: boolean;
+  saving: boolean;
+  dirty: boolean;
+  draft: Draft;
+  startEditing: () => void;
+  cancel: () => void;
+  save: () => Promise<void>;
+  setField: <K extends keyof Draft>(key: K, value: Draft[K]) => void;
+  album: AlbumWithTracks;
+};
+
+const EditContext = createContext<EditContextValue | null>(null);
+
+export function useAlbumEdit(): EditContextValue {
+  const ctx = useContext(EditContext);
+  if (!ctx) throw new Error("useAlbumEdit must be used within <AlbumEditProvider>");
+  return ctx;
+}
+
+function draftFrom(album: AlbumWithTracks): Draft {
+  return {
+    name: album.name,
+    description: album.description ?? "",
+    type: album.type ?? "album",
+  };
+}
+
+export function AlbumEditProvider({
+  album,
+  children,
+}: {
+  album: AlbumWithTracks;
+  children: React.ReactNode;
+}) {
+  const [canEdit, setCanEdit] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [draft, setDraft] = useState<Draft>(() => draftFrom(album));
+
+  useEffect(() => {
+    let active = true;
+    getMyArtistIds()
+      .then((ids) => {
+        if (active) setCanEdit(album.artist_id ? ids.has(album.artist_id) : false);
+      })
+      .catch(() => {
+        if (active) setCanEdit(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [album.artist_id]);
+
+  const dirty = useMemo(
+    () =>
+      draft.name !== album.name ||
+      draft.description !== (album.description ?? "") ||
+      draft.type !== (album.type ?? "album"),
+    [draft, album]
+  );
+
+  const startEditing = useCallback(() => setEditing(true), []);
+
+  const cancel = useCallback(() => {
+    setDraft(draftFrom(album));
+    setEditing(false);
+  }, [album]);
+
+  const setField = useCallback(
+    <K extends keyof Draft>(key: K, value: Draft[K]) =>
+      setDraft((d) => ({ ...d, [key]: value })),
+    []
+  );
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      if (dirty) {
+        await updateAlbum(album.id, draft.name, draft.description || null, draft.type);
+      }
+      setEditing(false);
+      // Reflect the saved values without a full reload.
+      album.name = draft.name;
+      album.description = draft.description || null;
+      album.type = draft.type;
+    } catch (err) {
+      console.error("Save failed", err);
+      alert("Save failed: " + (err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [album, draft, dirty]);
+
+  const value = useMemo<EditContextValue>(
+    () => ({
+      canEdit,
+      editing,
+      saving,
+      dirty,
+      draft,
+      startEditing,
+      cancel,
+      save,
+      setField,
+      album,
+    }),
+    [canEdit, editing, saving, dirty, draft, startEditing, cancel, save, setField, album]
+  );
+
+  return <EditContext.Provider value={value}>{children}</EditContext.Provider>;
+}

--- a/src/components/edit/AlbumTypeSelect.tsx
+++ b/src/components/edit/AlbumTypeSelect.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ALBUM_TYPES } from "@/lib/edit";
+
+export default function AlbumTypeSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      aria-label="Album type"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ font: "inherit", padding: "4px 8px", borderRadius: 6 }}
+    >
+      {ALBUM_TYPES.map((t) => (
+        <option key={t} value={t}>
+          {t.charAt(0).toUpperCase() + t.slice(1)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/edit/CoverUploader.module.css
+++ b/src/components/edit/CoverUploader.module.css
@@ -4,7 +4,11 @@
 }
 .overlay {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  width: var(--size);
+  height: var(--size);
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -12,7 +16,8 @@
   gap: 4px;
   border: none;
   cursor: pointer;
-  border-radius: 8px;
+  border-radius: calc(var(--size) * 0.05) calc(var(--size) * 0.1)
+    calc(var(--size) * 0.1) calc(var(--size) * 0.05);
   color: #fff;
   font: inherit;
   font-size: 12px;
@@ -20,7 +25,7 @@
   opacity: 0;
   transition: opacity 0.15s;
 }
-.wrap:hover .overlay,
+.overlay:hover,
 .overlay:focus-visible {
   opacity: 1;
 }

--- a/src/components/edit/CoverUploader.module.css
+++ b/src/components/edit/CoverUploader.module.css
@@ -1,0 +1,30 @@
+.wrap {
+  position: relative;
+  display: inline-block;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+  color: #fff;
+  font: inherit;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.wrap:hover .overlay,
+.overlay:focus-visible {
+  opacity: 1;
+}
+.overlay:disabled {
+  opacity: 1;
+  cursor: default;
+}

--- a/src/components/edit/CoverUploader.tsx
+++ b/src/components/edit/CoverUploader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, type CSSProperties } from "react";
 import { Upload } from "lucide-react";
 import AlbumCover from "../AlbumCover";
 import { uploadAlbumCover } from "@/lib/edit";
@@ -39,7 +39,10 @@ export default function CoverUploader({
   }
 
   return (
-    <div className={styles.wrap}>
+    <div
+      className={styles.wrap}
+      style={{ "--size": `${size}px` } as CSSProperties}
+    >
       <AlbumCover coverUrl={url} alt={alt} size={size} priority />
       <button
         type="button"

--- a/src/components/edit/CoverUploader.tsx
+++ b/src/components/edit/CoverUploader.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload } from "lucide-react";
+import AlbumCover from "../AlbumCover";
+import { uploadAlbumCover } from "@/lib/edit";
+import styles from "./CoverUploader.module.css";
+
+export default function CoverUploader({
+  albumId,
+  coverUrl,
+  alt,
+  size,
+}: {
+  albumId: string;
+  coverUrl: string | null;
+  alt: string;
+  size: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [url, setUrl] = useState(coverUrl);
+  const [busy, setBusy] = useState(false);
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setBusy(true);
+    try {
+      const next = await uploadAlbumCover(albumId, file);
+      // cache-bust so the <img> re-fetches the replaced object
+      setUrl(`${next}?v=${Date.now()}`);
+    } catch (err) {
+      console.error("cover upload", err);
+      alert("Cover upload failed: " + (err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <AlbumCover coverUrl={url} alt={alt} size={size} priority />
+      <button
+        type="button"
+        className={styles.overlay}
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        aria-label="Replace cover"
+      >
+        <Upload size={20} strokeWidth={2} />
+        <span>{busy ? "Uploading…" : "Replace"}</span>
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={onPick}
+      />
+    </div>
+  );
+}

--- a/src/components/edit/EditToggle.module.css
+++ b/src/components/edit/EditToggle.module.css
@@ -1,0 +1,32 @@
+.edit,
+.save,
+.cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  background: rgba(128, 128, 128, 0.08);
+  color: inherit;
+}
+
+.actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.save {
+  background: #5b8cff;
+  border-color: #5b8cff;
+  color: #fff;
+}
+
+.save:disabled,
+.cancel:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/components/edit/EditToggle.tsx
+++ b/src/components/edit/EditToggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Pencil, Check, X } from "lucide-react";
+import { useAlbumEdit } from "./AlbumEditProvider";
+import styles from "./EditToggle.module.css";
+
+export default function EditToggle() {
+  const { canEdit, editing, saving, startEditing, cancel, save } = useAlbumEdit();
+  if (!canEdit) return null;
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        className={styles.edit}
+        onClick={startEditing}
+        aria-label="Edit album"
+      >
+        <Pencil size={16} strokeWidth={2} />
+        <span>Edit</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.actions}>
+      <button
+        type="button"
+        className={styles.cancel}
+        onClick={cancel}
+        disabled={saving}
+      >
+        <X size={16} strokeWidth={2} />
+        <span>Cancel</span>
+      </button>
+      <button
+        type="button"
+        className={styles.save}
+        onClick={save}
+        disabled={saving}
+      >
+        <Check size={16} strokeWidth={2} />
+        <span>{saving ? "Saving…" : "Save"}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/edit/EditableSetlist.module.css
+++ b/src/components/edit/EditableSetlist.module.css
@@ -1,0 +1,79 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(91, 140, 255, 0.06);
+}
+.num {
+  width: 18px;
+  color: rgba(128, 128, 128, 0.8);
+  font-size: 13px;
+}
+.name {
+  flex: 1;
+}
+.pending {
+  color: #5b8cff;
+  font-style: italic;
+  font-size: 12px;
+}
+.controls {
+  display: inline-flex;
+  gap: 2px;
+}
+.controls button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 4px;
+  display: inline-flex;
+  border-radius: 4px;
+}
+.controls button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.remove {
+  color: #e5484d;
+}
+.add {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+.add input {
+  flex: 1;
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  background: transparent;
+  color: inherit;
+}
+.add button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  background: rgba(128, 128, 128, 0.08);
+  color: inherit;
+  cursor: pointer;
+}
+.hint {
+  font-size: 12px;
+  color: rgba(128, 128, 128, 0.85);
+  margin-top: 6px;
+}

--- a/src/components/edit/EditableSetlist.module.css
+++ b/src/components/edit/EditableSetlist.module.css
@@ -11,6 +11,19 @@
   border-radius: 6px;
   background: rgba(91, 140, 255, 0.06);
 }
+.expand {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 4px;
+  display: inline-flex;
+  border-radius: 4px;
+}
+.expand:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
 .num {
   width: 18px;
   color: rgba(128, 128, 128, 0.8);

--- a/src/components/edit/EditableSetlist.tsx
+++ b/src/components/edit/EditableSetlist.tsx
@@ -1,49 +1,78 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowUp, ArrowDown, X, Plus } from "lucide-react";
+import {
+  ArrowUp,
+  ArrowDown,
+  X,
+  Plus,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
 import { useAlbumEdit } from "./AlbumEditProvider";
+import VersionsPanel from "./VersionsPanel";
 import styles from "./EditableSetlist.module.css";
 
 export default function EditableSetlist() {
   const { setlist, moveItem, removeItem, addItem } = useAlbumEdit();
   const [name, setName] = useState("");
+  const [openKey, setOpenKey] = useState<string | null>(null);
 
   return (
     <div className={styles.list}>
       {setlist.map((item, i) => (
-        <div key={item.key} className={styles.row}>
-          <span className={styles.num}>{i + 1}</span>
-          <span className={styles.name}>
-            {item.name}
-            {!item.trackId && <em className={styles.pending}> · new</em>}
-          </span>
-          <div className={styles.controls}>
+        <div key={item.key}>
+          <div className={styles.row}>
             <button
               type="button"
-              aria-label="Move up"
-              disabled={i === 0}
-              onClick={() => moveItem(i, -1)}
+              aria-label="Toggle versions"
+              className={styles.expand}
+              disabled={!item.trackId}
+              onClick={() =>
+                setOpenKey((k) => (k === item.key ? null : item.key))
+              }
             >
-              <ArrowUp size={16} />
+              {openKey === item.key ? (
+                <ChevronDown size={16} />
+              ) : (
+                <ChevronRight size={16} />
+              )}
             </button>
-            <button
-              type="button"
-              aria-label="Move down"
-              disabled={i === setlist.length - 1}
-              onClick={() => moveItem(i, 1)}
-            >
-              <ArrowDown size={16} />
-            </button>
-            <button
-              type="button"
-              aria-label="Remove"
-              className={styles.remove}
-              onClick={() => removeItem(item.key)}
-            >
-              <X size={16} />
-            </button>
+            <span className={styles.num}>{i + 1}</span>
+            <span className={styles.name}>
+              {item.name}
+              {!item.trackId && <em className={styles.pending}> · new</em>}
+            </span>
+            <div className={styles.controls}>
+              <button
+                type="button"
+                aria-label="Move up"
+                disabled={i === 0}
+                onClick={() => moveItem(i, -1)}
+              >
+                <ArrowUp size={16} />
+              </button>
+              <button
+                type="button"
+                aria-label="Move down"
+                disabled={i === setlist.length - 1}
+                onClick={() => moveItem(i, 1)}
+              >
+                <ArrowDown size={16} />
+              </button>
+              <button
+                type="button"
+                aria-label="Remove"
+                className={styles.remove}
+                onClick={() => removeItem(item.key)}
+              >
+                <X size={16} />
+              </button>
+            </div>
           </div>
+          {openKey === item.key && item.trackId && (
+            <VersionsPanel trackId={item.trackId} />
+          )}
         </div>
       ))}
       <form

--- a/src/components/edit/EditableSetlist.tsx
+++ b/src/components/edit/EditableSetlist.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUp, ArrowDown, X, Plus } from "lucide-react";
+import { useAlbumEdit } from "./AlbumEditProvider";
+import styles from "./EditableSetlist.module.css";
+
+export default function EditableSetlist() {
+  const { setlist, moveItem, removeItem, addItem } = useAlbumEdit();
+  const [name, setName] = useState("");
+
+  return (
+    <div className={styles.list}>
+      {setlist.map((item, i) => (
+        <div key={item.key} className={styles.row}>
+          <span className={styles.num}>{i + 1}</span>
+          <span className={styles.name}>
+            {item.name}
+            {!item.trackId && <em className={styles.pending}> · new</em>}
+          </span>
+          <div className={styles.controls}>
+            <button
+              type="button"
+              aria-label="Move up"
+              disabled={i === 0}
+              onClick={() => moveItem(i, -1)}
+            >
+              <ArrowUp size={16} />
+            </button>
+            <button
+              type="button"
+              aria-label="Move down"
+              disabled={i === setlist.length - 1}
+              onClick={() => moveItem(i, 1)}
+            >
+              <ArrowDown size={16} />
+            </button>
+            <button
+              type="button"
+              aria-label="Remove"
+              className={styles.remove}
+              onClick={() => removeItem(item.key)}
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+      ))}
+      <form
+        className={styles.add}
+        onSubmit={(e) => {
+          e.preventDefault();
+          addItem(name);
+          setName("");
+        }}
+      >
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="New track name…"
+          aria-label="New track name"
+        />
+        <button type="submit" disabled={!name.trim()}>
+          <Plus size={16} /> Add
+        </button>
+      </form>
+      <p className={styles.hint}>
+        Order &amp; track changes apply when you Save. Add audio to a track after
+        saving.
+      </p>
+    </div>
+  );
+}

--- a/src/components/edit/EditableText.tsx
+++ b/src/components/edit/EditableText.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRef } from "react";
+
+type Props = {
+  value: string;
+  onCommit: (value: string) => void;
+  className?: string;
+  placeholder?: string;
+  multiline?: boolean;
+  ariaLabel: string;
+};
+
+export default function EditableText({
+  value,
+  onCommit,
+  className,
+  placeholder,
+  multiline = false,
+  ariaLabel,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={ref}
+      role="textbox"
+      aria-label={ariaLabel}
+      contentEditable
+      suppressContentEditableWarning
+      className={className}
+      data-placeholder={placeholder}
+      style={{
+        outline: "1px dashed rgba(91,140,255,0.6)",
+        borderRadius: 6,
+        padding: "2px 6px",
+        minHeight: "1em",
+      }}
+      onKeyDown={(e) => {
+        if (!multiline && e.key === "Enter") {
+          e.preventDefault();
+          ref.current?.blur();
+        }
+      }}
+      onBlur={(e) => onCommit(e.currentTarget.textContent ?? "")}
+    >
+      {value}
+    </div>
+  );
+}

--- a/src/components/edit/GenrePicker.module.css
+++ b/src/components/edit/GenrePicker.module.css
@@ -46,8 +46,10 @@
   list-style: none;
   padding: 4px;
   border-radius: 8px;
-  background: var(--background, #fff);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  background: var(--album-deep, #1c1420);
+  color: var(--album-light, #f2eff5);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
   max-height: 200px;
   overflow-y: auto;
   min-width: 200px;
@@ -68,7 +70,7 @@
   border-radius: 6px;
 }
 .menu button:hover {
-  background: rgba(128, 128, 128, 0.12);
+  background: rgba(255, 255, 255, 0.12);
 }
 .create {
   color: #5b8cff;

--- a/src/components/edit/GenrePicker.module.css
+++ b/src/components/edit/GenrePicker.module.css
@@ -1,0 +1,75 @@
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(91, 140, 255, 0.15);
+  color: #5b8cff;
+}
+.chip button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+}
+.inputWrap {
+  position: relative;
+}
+.input {
+  font: inherit;
+  font-size: 13px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  max-width: 220px;
+}
+.menu {
+  position: absolute;
+  z-index: 20;
+  margin-top: 2px;
+  list-style: none;
+  padding: 4px;
+  border-radius: 8px;
+  background: var(--background, #fff);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  max-height: 200px;
+  overflow-y: auto;
+  min-width: 200px;
+}
+.menu button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.menu button:hover {
+  background: rgba(128, 128, 128, 0.12);
+}
+.create {
+  color: #5b8cff;
+}

--- a/src/components/edit/GenrePicker.tsx
+++ b/src/components/edit/GenrePicker.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { X, Plus } from "lucide-react";
+import type { Genre } from "@/lib/types";
+import { getGenres } from "@/lib/data";
+import { createGenre } from "@/lib/edit";
+import styles from "./GenrePicker.module.css";
+
+export default function GenrePicker({
+  selected,
+  onChange,
+}: {
+  selected: Genre[];
+  onChange: (genres: Genre[]) => void;
+}) {
+  const [all, setAll] = useState<Genre[]>([]);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    getGenres()
+      .then(setAll)
+      .catch((e) => console.error("load genres", e));
+  }, []);
+
+  const selectedIds = useMemo(
+    () => new Set(selected.map((g) => g.id)),
+    [selected]
+  );
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return all.filter(
+      (g) => !selectedIds.has(g.id) && (!q || g.name.toLowerCase().includes(q))
+    );
+  }, [all, query, selectedIds]);
+
+  const exact = all.some(
+    (g) => g.name.toLowerCase() === query.trim().toLowerCase()
+  );
+
+  function add(g: Genre) {
+    onChange([...selected, g]);
+    setQuery("");
+    setOpen(false);
+  }
+  function remove(id: string) {
+    onChange(selected.filter((g) => g.id !== id));
+  }
+  async function createAndAdd() {
+    const name = query.trim();
+    if (!name) return;
+    try {
+      const g = await createGenre(name);
+      setAll((prev) => (prev.some((x) => x.id === g.id) ? prev : [...prev, g]));
+      add(g);
+    } catch (e) {
+      console.error("create genre", e);
+      alert("Could not create genre: " + (e as Error).message);
+    }
+  }
+
+  return (
+    <div className={styles.picker}>
+      <div className={styles.chips}>
+        {selected.map((g) => (
+          <span key={g.id} className={styles.chip}>
+            {g.name}
+            <button
+              type="button"
+              aria-label={`Remove ${g.name}`}
+              onClick={() => remove(g.id)}
+            >
+              <X size={12} strokeWidth={2.5} />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className={styles.inputWrap}>
+        <input
+          className={styles.input}
+          value={query}
+          placeholder="Add genre…"
+          aria-label="Search or add genre"
+          onFocus={() => setOpen(true)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+        />
+        {open && (matches.length > 0 || (query.trim() && !exact)) && (
+          <ul className={styles.menu}>
+            {matches.map((g) => (
+              <li key={g.id}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => add(g)}
+                >
+                  {g.name}
+                </button>
+              </li>
+            ))}
+            {query.trim() && !exact && (
+              <li>
+                <button
+                  type="button"
+                  className={styles.create}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={createAndAdd}
+                >
+                  <Plus size={14} strokeWidth={2.5} /> Create “{query.trim()}”
+                </button>
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/edit/VersionsPanel.module.css
+++ b/src/components/edit/VersionsPanel.module.css
@@ -1,0 +1,73 @@
+.panel {
+  padding: 8px 10px;
+  margin: 2px 0 6px 26px;
+  border-left: 2px solid rgba(91, 140, 255, 0.3);
+}
+.muted {
+  color: rgba(128, 128, 128, 0.85);
+  font-size: 12px;
+}
+.versions {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.version {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.vName {
+  flex: 1;
+}
+.date {
+  color: rgba(128, 128, 128, 0.8);
+  font-size: 12px;
+}
+.ok {
+  color: #30a46c;
+}
+.del {
+  background: none;
+  border: none;
+  color: #e5484d;
+  cursor: pointer;
+  display: inline-flex;
+}
+.add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.add input[type="text"],
+.add input:not([type]),
+.add select {
+  font: inherit;
+  font-size: 13px;
+  padding: 5px 7px;
+  border-radius: 6px;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  background: transparent;
+  color: inherit;
+}
+.add button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: inherit;
+  font-size: 13px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid #5b8cff;
+  background: #5b8cff;
+  color: #fff;
+  cursor: pointer;
+}
+.add button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/components/edit/VersionsPanel.tsx
+++ b/src/components/edit/VersionsPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Trash2, Upload } from "lucide-react";
+import type { AlbumVersion } from "@/lib/types";
+import {
+  listTrackVersions,
+  createVersionWithFile,
+  updateVersion,
+  deleteVersion,
+  VERSION_STATUSES,
+} from "@/lib/edit";
+import styles from "./VersionsPanel.module.css";
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function VersionsPanel({ trackId }: { trackId: string }) {
+  const [versions, setVersions] = useState<AlbumVersion[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState<string>("demo");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const reload = () =>
+    listTrackVersions(trackId)
+      .then(setVersions)
+      .catch((e) => console.error("load versions", e));
+
+  useEffect(() => {
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trackId]);
+
+  async function onAdd() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      alert("Pick an audio file first.");
+      return;
+    }
+    if (!name.trim()) {
+      alert("Name the version first.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await createVersionWithFile(trackId, name.trim(), status, today(), file);
+      setName("");
+      if (fileRef.current) fileRef.current.value = "";
+      await reload();
+    } catch (e) {
+      console.error("create version", e);
+      alert("Upload failed: " + (e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onStatusChange(v: AlbumVersion, next: string) {
+    setVersions((list) =>
+      list?.map((x) => (x.id === v.id ? { ...x, status: next } : x)) ?? null
+    );
+    try {
+      await updateVersion(v.id, v.name, next, v.release_date);
+    } catch (e) {
+      console.error("update version", e);
+      await reload();
+    }
+  }
+
+  async function onDelete(v: AlbumVersion) {
+    if (!confirm(`Delete version “${v.name}”?`)) return;
+    try {
+      await deleteVersion(v.id);
+      await reload();
+    } catch (e) {
+      console.error("delete version", e);
+      alert("Delete failed: " + (e as Error).message);
+    }
+  }
+
+  return (
+    <div className={styles.panel}>
+      {versions === null ? (
+        <p className={styles.muted}>Loading versions…</p>
+      ) : versions.length === 0 ? (
+        <p className={styles.muted}>No versions yet.</p>
+      ) : (
+        <ul className={styles.versions}>
+          {versions.map((v) => (
+            <li key={v.id} className={styles.version}>
+              <span className={styles.vName}>{v.name}</span>
+              <select
+                value={v.status}
+                aria-label={`Status of ${v.name}`}
+                onChange={(e) => onStatusChange(v, e.target.value)}
+              >
+                {VERSION_STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <span className={styles.date}>{v.release_date}</span>
+              {v.resource_url ? (
+                <span className={styles.ok}>♪</span>
+              ) : (
+                <span className={styles.muted}>no file</span>
+              )}
+              <button
+                type="button"
+                aria-label={`Delete ${v.name}`}
+                className={styles.del}
+                onClick={() => onDelete(v)}
+              >
+                <Trash2 size={15} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className={styles.add}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Version name…"
+          aria-label="New version name"
+        />
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          aria-label="New version status"
+        >
+          {VERSION_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <input ref={fileRef} type="file" accept="audio/*,.m4a" aria-label="Audio file" />
+        <button type="button" onClick={onAdd} disabled={busy}>
+          <Upload size={15} /> {busy ? "Uploading…" : "Add version"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,8 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "./supabase/anon";
-import type { Album, AlbumWithTracks, Track, TrackLyrics } from "./types";
+import type { Album, AlbumWithTracks, Genre, Track, TrackLyrics } from "./types";
 
-const ALBUM_COLS = "id,name,description,type,cover_url,created_at";
+const ALBUM_COLS = "id,artist_id,name,description,type,cover_url,created_at";
 
 /** Supabase errors are plain objects; wrap them so logs show a real message. */
 function fail(context: string, error: { message?: string }): never {
@@ -22,6 +22,7 @@ function groupTracks(albums: Album[], tracks: Track[]): AlbumWithTracks[] {
   return albums.map((album) => ({
     ...album,
     tracks: byAlbum.get(album.id) ?? [],
+    genres: [],
   }));
 }
 
@@ -50,22 +51,46 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
 export async function getAlbumWithTracks(
   id: string
 ): Promise<AlbumWithTracks | null> {
-  const [albumRes, tracksRes] = await Promise.all([
+  const [albumRes, tracksRes, orderRes, genresRes] = await Promise.all([
     supabase.from("albums").select(ALBUM_COLS).eq("id", id).maybeSingle(),
+    supabase.from("track_overview").select(TRACK_COLS).eq("album_id", id),
+    supabase.from("album_tracks").select("track_id,position").eq("album_id", id),
     supabase
-      .from("track_overview")
-      .select(TRACK_COLS)
-      .eq("album_id", id)
-      .order("latest_release_date", { ascending: false }),
+      .from("album_genres")
+      .select("genres(id,name,slug)")
+      .eq("album_id", id),
   ]);
 
   if (albumRes.error || !albumRes.data) return null;
   if (tracksRes.error) fail("Failed to load album tracks", tracksRes.error);
 
-  return {
-    ...(albumRes.data as Album),
-    tracks: (tracksRes.data ?? []) as Track[],
-  };
+  const position = new Map(
+    (orderRes.data ?? []).map((r) => [
+      r.track_id as string,
+      r.position as number,
+    ])
+  );
+  const tracks = ((tracksRes.data ?? []) as Track[]).slice().sort(
+    (a, b) =>
+      (position.get(a.track_id) ?? Number.MAX_SAFE_INTEGER) -
+      (position.get(b.track_id) ?? Number.MAX_SAFE_INTEGER)
+  );
+
+  const genres = (genresRes.data ?? [])
+    .map((row) => (row as unknown as { genres: Genre | null }).genres)
+    .filter((g): g is Genre => Boolean(g));
+
+  return { ...(albumRes.data as Album), tracks, genres };
+}
+
+/** All genres, alphabetical — powers the edit combobox. */
+export async function getGenres(): Promise<Genre[]> {
+  const { data, error } = await supabase
+    .from("genres")
+    .select("id,name,slug")
+    .order("name");
+  if (error) fail("Failed to load genres", error);
+  return (data ?? []) as Genre[];
 }
 
 export async function getLyrics(trackIds: string[]): Promise<TrackLyrics> {

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -1,0 +1,195 @@
+import { createClient } from "@/lib/supabase/client";
+import type { AlbumVersion, Genre } from "@/lib/types";
+
+/** Artist ids the signed-in user may edit (own artist_members rows, RLS-scoped). */
+export async function getMyArtistIds(): Promise<Set<string>> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("artist_members")
+    .select("artist_id");
+  if (error) throw new Error(error.message);
+  return new Set((data ?? []).map((r) => r.artist_id as string));
+}
+
+export async function updateAlbum(
+  albumId: string,
+  name: string,
+  description: string | null,
+  type: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("update_album", {
+    _album_id: albumId,
+    _name: name,
+    _description: description,
+    _type: type,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function setAlbumGenres(
+  albumId: string,
+  genreIds: string[]
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("set_album_genres", {
+    _album_id: albumId,
+    _genre_ids: genreIds,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function createGenre(name: string): Promise<Genre> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_genre", { _name: name });
+  if (error) throw new Error(error.message);
+  return data as Genre;
+}
+
+export async function createTrack(
+  albumId: string,
+  name: string
+): Promise<string> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_track", {
+    _album_id: albumId,
+    _name: name,
+    _description: null,
+    _lyrics: null,
+  });
+  if (error) throw new Error(error.message);
+  return (data as { id: string }).id;
+}
+
+export async function removeTrackFromAlbum(
+  albumId: string,
+  trackId: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("remove_track_from_album", {
+    _album_id: albumId,
+    _track_id: trackId,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function reorderSetlist(
+  albumId: string,
+  orderedTrackIds: string[]
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("reorder_setlist", {
+    _album_id: albumId,
+    _ordered_track_ids: orderedTrackIds,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** Upload a cover to the `covers` bucket and record its public URL. */
+export async function uploadAlbumCover(
+  albumId: string,
+  file: File
+): Promise<string> {
+  const supabase = createClient();
+  const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+  const path = `${albumId}/cover.${ext}`;
+  const up = await supabase.storage
+    .from("covers")
+    .upload(path, file, { upsert: true });
+  if (up.error) throw new Error(up.error.message);
+  const url = supabase.storage.from("covers").getPublicUrl(path).data.publicUrl;
+  const { error } = await supabase.rpc("set_album_cover", {
+    _album_id: albumId,
+    _cover_url: url,
+  });
+  if (error) throw new Error(error.message);
+  return url;
+}
+
+/** All versions of a track, newest release first (edit view). */
+export async function listTrackVersions(
+  trackId: string
+): Promise<AlbumVersion[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("track_versions")
+    .select("versions(id,name,status,release_date,resource_url)")
+    .eq("track_id", trackId);
+  if (error) throw new Error(error.message);
+  return (data ?? [])
+    .map((row) => (row as unknown as { versions: AlbumVersion | null }).versions)
+    .filter((v): v is AlbumVersion => Boolean(v))
+    .sort((a, b) => b.release_date.localeCompare(a.release_date));
+}
+
+export async function updateVersion(
+  versionId: string,
+  name: string,
+  status: string,
+  releaseDate: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("update_version", {
+    _version_id: versionId,
+    _name: name,
+    _status: status,
+    _release_date: releaseDate,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function deleteVersion(versionId: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("delete_version", {
+    _version_id: versionId,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** Create a version row, upload its audio, and record the URL. Returns the id. */
+export async function createVersionWithFile(
+  trackId: string,
+  name: string,
+  status: string,
+  releaseDate: string,
+  file: File
+): Promise<string> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc("create_version", {
+    _track_id: trackId,
+    _name: name,
+    _status: status,
+    _release_date: releaseDate,
+  });
+  if (error) throw new Error(error.message);
+  // create_version RETURNS TABLE(...) → PostgREST returns an array of rows.
+  const row = (data as { version_id: string; upload_path: string }[])[0];
+  if (!row) throw new Error("create_version returned no row");
+  const { version_id, upload_path } = row;
+
+  const up = await supabase.storage
+    .from("versions")
+    .upload(upload_path, file, { upsert: true });
+  if (up.error) throw new Error(up.error.message);
+  const url = supabase.storage
+    .from("versions")
+    .getPublicUrl(upload_path).data.publicUrl;
+
+  const setErr = (
+    await supabase.rpc("set_version_file", {
+      _version_id: version_id,
+      _resource_url: url,
+    })
+  ).error;
+  if (setErr) throw new Error(setErr.message);
+  return version_id;
+}
+
+export const VERSION_STATUSES = [
+  "raw",
+  "draft",
+  "demo",
+  "prototype",
+  "final",
+] as const;
+export const ALBUM_TYPES = ["single", "ep", "album"] as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,10 +1,22 @@
 export type Album = {
   id: string;
+  artist_id: string | null;
   name: string;
   description: string | null;
   type: string | null;
   cover_url: string | null;
   created_at: string;
+};
+
+export type Genre = { id: string; name: string; slug: string };
+
+/** A full row of public.versions (edit view — the read view uses Track). */
+export type AlbumVersion = {
+  id: string;
+  name: string;
+  status: string;
+  release_date: string;
+  resource_url: string | null;
 };
 
 /** One row of the `track_overview` Supabase view. */
@@ -24,6 +36,7 @@ export type Track = {
 
 export type AlbumWithTracks = Album & {
   tracks: Track[];
+  genres: Genre[];
 };
 
 export type TrackLyrics = Record<string, string | null>;

--- a/supabase/migrations/20260712000100_artist_members.sql
+++ b/supabase/migrations/20260712000100_artist_members.sql
@@ -1,0 +1,39 @@
+-- Roles layer: which users may manage which artist, plus the membership guard
+-- every content RPC calls first.
+
+create table if not exists public.artist_members (
+  artist_id  uuid not null references public.artists(id) on delete cascade,
+  user_id    uuid not null references auth.users(id)     on delete cascade,
+  role       text not null check (role in ('owner','maintainer')),
+  created_at timestamptz not null default now(),
+  primary key (artist_id, user_id)
+);
+
+alter table public.artist_members enable row level security;
+
+-- A member may read their own membership rows (enough to compute canEdit). This
+-- is intentionally non-recursive: a policy that sub-queries artist_members would
+-- trigger "infinite recursion detected in policy". No client writes: memberships
+-- are seeded manually in the dashboard for now.
+drop policy if exists "members read own artist memberships" on public.artist_members;
+create policy "members read own artist memberships"
+  on public.artist_members for select
+  using (user_id = auth.uid());
+
+-- SECURITY DEFINER so it can read artist_members regardless of the caller's RLS.
+create or replace function public.is_artist_member(_artist_id uuid)
+  returns boolean
+  language sql
+  security definer
+  set search_path = public, pg_temp
+  stable
+as $$
+  select exists (
+    select 1 from public.artist_members m
+    where m.artist_id = _artist_id
+      and m.user_id = auth.uid()
+  );
+$$;
+
+revoke all on function public.is_artist_member(uuid) from public;
+grant execute on function public.is_artist_member(uuid) to anon, authenticated;

--- a/supabase/migrations/20260712000200_genres.sql
+++ b/supabase/migrations/20260712000200_genres.sql
@@ -1,0 +1,43 @@
+-- Controlled genre vocabulary (searchable combobox source) + album links.
+
+-- Full slug helper (genres appear in URLs/filters, not storage paths, so unlike
+-- track/artist 3-char slugs this is a real slug).
+create or replace function public.slugify(_text text)
+  returns text language sql immutable as $$
+  select trim(both '-' from regexp_replace(lower(coalesce(_text,'')), '[^a-z0-9]+', '-', 'g'));
+$$;
+
+create table if not exists public.genres (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null unique,
+  slug       text not null default '',
+  created_at timestamptz not null default now()
+);
+
+-- Keep slug in sync with name via trigger (a plain default can't reference name
+-- reliably across updates).
+create or replace function public.genres_set_slug()
+  returns trigger language plpgsql as $$
+begin
+  new.slug := public.slugify(new.name);
+  return new;
+end $$;
+
+drop trigger if exists genres_slug on public.genres;
+create trigger genres_slug before insert or update of name on public.genres
+  for each row execute function public.genres_set_slug();
+
+create table if not exists public.album_genres (
+  album_id uuid not null references public.albums(id) on delete cascade,
+  genre_id uuid not null references public.genres(id) on delete cascade,
+  primary key (album_id, genre_id)
+);
+
+alter table public.genres       enable row level security;
+alter table public.album_genres enable row level security;
+
+drop policy if exists "public read genres" on public.genres;
+create policy "public read genres" on public.genres for select using (true);
+
+drop policy if exists "public read album_genres" on public.album_genres;
+create policy "public read album_genres" on public.album_genres for select using (true);

--- a/supabase/migrations/20260712000300_albums_artist_id.sql
+++ b/supabase/migrations/20260712000300_albums_artist_id.sql
@@ -1,0 +1,8 @@
+-- Associate every album with an artist. Backfill existing albums to bohns.
+
+alter table public.albums
+  add column if not exists artist_id uuid references public.artists(id);
+
+update public.albums
+  set artist_id = (select id from public.artists where lower(name) = 'bohns' limit 1)
+  where artist_id is null;

--- a/supabase/migrations/20260712000400_album_tracks_position.sql
+++ b/supabase/migrations/20260712000400_album_tracks_position.sql
@@ -1,0 +1,15 @@
+-- Explicit setlist order within an album. Backfill from insertion order.
+
+alter table public.album_tracks
+  add column if not exists position int;
+
+with ordered as (
+  select id,
+         row_number() over (partition by album_id order by created_at, id) as rn
+  from public.album_tracks
+)
+update public.album_tracks at
+  set position = ordered.rn
+  from ordered
+  where ordered.id = at.id
+    and at.position is null;

--- a/supabase/migrations/20260712000500_content_read_policies.sql
+++ b/supabase/migrations/20260712000500_content_read_policies.sql
@@ -1,0 +1,28 @@
+-- Ensure public read on artists + content, and (idempotently) that RLS is on.
+-- Writes are intentionally NOT granted to client roles; SECURITY DEFINER RPCs
+-- (Tasks 6-9) are the only write path.
+
+alter table public.artists        enable row level security;
+alter table public.albums         enable row level security;
+alter table public.tracks         enable row level security;
+alter table public.versions       enable row level security;
+alter table public.album_tracks   enable row level security;
+alter table public.track_versions enable row level security;
+
+drop policy if exists "public read artists" on public.artists;
+create policy "public read artists" on public.artists for select using (true);
+
+drop policy if exists "public read albums" on public.albums;
+create policy "public read albums" on public.albums for select using (true);
+
+drop policy if exists "public read tracks" on public.tracks;
+create policy "public read tracks" on public.tracks for select using (true);
+
+drop policy if exists "public read versions" on public.versions;
+create policy "public read versions" on public.versions for select using (true);
+
+drop policy if exists "public read album_tracks" on public.album_tracks;
+create policy "public read album_tracks" on public.album_tracks for select using (true);
+
+drop policy if exists "public read track_versions" on public.track_versions;
+create policy "public read track_versions" on public.track_versions for select using (true);

--- a/supabase/migrations/20260712000600_rpc_albums.sql
+++ b/supabase/migrations/20260712000600_rpc_albums.sql
@@ -1,0 +1,107 @@
+-- Album CRUD. Every function checks membership first and raises
+-- insufficient_privilege (42501) for non-members. Album type enum is
+-- public.album_type (values: single | ep | album).
+
+-- Guard: caller is a member of the album's artist.
+create or replace function public.is_member_of_album(_album_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select public.is_artist_member((select artist_id from public.albums where id = _album_id));
+$$;
+
+create or replace function public.create_album(
+  _artist_id   uuid,
+  _name        text,
+  _type        public.album_type,
+  _description text default null,
+  _genre_ids   uuid[] default '{}'
+) returns public.albums
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _album public.albums;
+begin
+  if not public.is_artist_member(_artist_id) then
+    raise exception 'not a member of artist %', _artist_id using errcode = '42501';
+  end if;
+  insert into public.albums (artist_id, name, type, description)
+    values (_artist_id, _name, _type, _description)
+    returning * into _album;
+  if array_length(_genre_ids, 1) is not null then
+    insert into public.album_genres (album_id, genre_id)
+      select _album.id, g from unnest(_genre_ids) g
+      on conflict do nothing;
+  end if;
+  return _album;
+end $$;
+
+create or replace function public.update_album(
+  _album_id    uuid,
+  _name        text,
+  _description text,
+  _type        public.album_type
+) returns public.albums
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _album public.albums;
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.albums
+    set name = _name, description = _description, type = _type
+    where id = _album_id
+    returning * into _album;
+  return _album;
+end $$;
+
+create or replace function public.delete_album(_album_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.albums where id = _album_id;
+end $$;
+
+create or replace function public.set_album_genres(_album_id uuid, _genre_ids uuid[])
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.album_genres where album_id = _album_id;
+  if array_length(_genre_ids, 1) is not null then
+    insert into public.album_genres (album_id, genre_id)
+      select _album_id, g from unnest(_genre_ids) g
+      on conflict do nothing;
+  end if;
+end $$;
+
+-- Client uploads the cover to Storage, then passes the SDK getPublicUrl() result
+-- here (machine-written, never hand-typed).
+create or replace function public.set_album_cover(_album_id uuid, _cover_url text)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.albums set cover_url = _cover_url where id = _album_id;
+end $$;
+
+revoke all on function
+  public.create_album(uuid,text,public.album_type,text,uuid[]),
+  public.update_album(uuid,text,text,public.album_type),
+  public.delete_album(uuid),
+  public.set_album_genres(uuid,uuid[]),
+  public.set_album_cover(uuid,text)
+  from public;
+grant execute on function
+  public.create_album(uuid,text,public.album_type,text,uuid[]),
+  public.update_album(uuid,text,text,public.album_type),
+  public.delete_album(uuid),
+  public.set_album_genres(uuid,uuid[]),
+  public.set_album_cover(uuid,text)
+  to authenticated;

--- a/supabase/migrations/20260712000700_rpc_tracks.sql
+++ b/supabase/migrations/20260712000700_rpc_tracks.sql
@@ -1,0 +1,117 @@
+-- Track CRUD + setlist ordering. create_track inserts the track AND the
+-- album_tracks link at the next position in one call.
+
+-- Guard: caller is a member of any artist that owns an album this track is on.
+create or replace function public.is_member_of_track(_track_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (
+    select 1
+    from public.album_tracks at
+    join public.albums a on a.id = at.album_id
+    where at.track_id = _track_id
+      and public.is_artist_member(a.artist_id)
+  );
+$$;
+
+create or replace function public.create_track(
+  _album_id    uuid,
+  _name        text,
+  _description text default null,
+  _lyrics      text default null
+) returns public.tracks
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _track public.tracks; _next int;
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  insert into public.tracks (name, description, lyrics)
+    values (_name, _description, _lyrics)
+    returning * into _track;
+  select coalesce(max(position), 0) + 1 into _next
+    from public.album_tracks where album_id = _album_id;
+  insert into public.album_tracks (album_id, track_id, position)
+    values (_album_id, _track.id, _next);
+  return _track;
+end $$;
+
+create or replace function public.update_track(
+  _track_id uuid, _name text, _description text, _lyrics text
+) returns public.tracks
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _track public.tracks;
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  update public.tracks set name=_name, description=_description, lyrics=_lyrics
+    where id=_track_id returning * into _track;
+  return _track;
+end $$;
+
+-- Unlink a track from one album (renumber remaining positions), keep the track row.
+create or replace function public.remove_track_from_album(_album_id uuid, _track_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  delete from public.album_tracks where album_id=_album_id and track_id=_track_id;
+  with ordered as (
+    select id, row_number() over (order by position, id) as rn
+    from public.album_tracks where album_id=_album_id
+  )
+  update public.album_tracks at set position = ordered.rn
+    from ordered where ordered.id = at.id;
+end $$;
+
+-- Delete a track everywhere: its album links, its version links, and its
+-- now-orphaned versions. (Version files are cleaned up client-side.)
+create or replace function public.delete_track(_track_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  delete from public.versions v
+    using public.track_versions tv
+    where tv.version_id = v.id and tv.track_id = _track_id;
+  delete from public.track_versions where track_id = _track_id;
+  delete from public.album_tracks where track_id = _track_id;
+  delete from public.tracks where id = _track_id;
+end $$;
+
+-- Reorder a whole album's setlist from an ordered array of track ids.
+create or replace function public.reorder_setlist(_album_id uuid, _ordered_track_ids uuid[])
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.album_tracks at
+    set position = ord.rn
+    from (select id, ordinality::int as rn
+          from unnest(_ordered_track_ids) with ordinality as u(id, ordinality)) ord
+    where at.album_id = _album_id and at.track_id = ord.id;
+end $$;
+
+revoke all on function
+  public.create_track(uuid,text,text,text),
+  public.update_track(uuid,text,text,text),
+  public.remove_track_from_album(uuid,uuid),
+  public.delete_track(uuid),
+  public.reorder_setlist(uuid,uuid[])
+  from public;
+grant execute on function
+  public.create_track(uuid,text,text,text),
+  public.update_track(uuid,text,text,text),
+  public.remove_track_from_album(uuid,uuid),
+  public.delete_track(uuid),
+  public.reorder_setlist(uuid,uuid[])
+  to authenticated;

--- a/supabase/migrations/20260712000800_rpc_versions.sql
+++ b/supabase/migrations/20260712000800_rpc_versions.sql
@@ -1,0 +1,95 @@
+-- Version CRUD. create_version inserts the version + track_versions link and
+-- returns the deterministic Storage upload path. set_version_file stores the
+-- client's SDK-derived public URL. versions.track_id kept in sync (junction stays
+-- canonical).
+
+create or replace function public.is_member_of_version(_version_id uuid)
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (
+    select 1 from public.track_versions tv
+    where tv.version_id = _version_id
+      and public.is_member_of_track(tv.track_id)
+  );
+$$;
+
+create or replace function public.create_version(
+  _track_id     uuid,
+  _name         text,
+  _status       public.version_status,
+  _release_date date default current_date
+) returns table (version_id uuid, upload_path text)
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _vid uuid; _slug text; _tid uuid := _track_id;
+begin
+  if not public.is_member_of_track(_track_id) then
+    raise exception 'not a member of this track''s artist' using errcode = '42501';
+  end if;
+  select slug into _slug from public.tracks where id = _track_id;
+  insert into public.versions (name, status, release_date, track_id)
+    values (_name, _status, _release_date, _track_id)
+    returning id into _vid;
+  -- A trigger auto-links track_versions from versions.track_id. Keep this
+  -- idempotent (works with or without the trigger) and table-qualified so
+  -- version_id is unambiguous against the OUT parameter of the same name.
+  insert into public.track_versions (track_id, version_id)
+  select _track_id, _vid
+  where not exists (
+    select 1 from public.track_versions tv
+    where tv.track_id = _track_id and tv.version_id = _vid
+  );
+  version_id  := _vid;
+  upload_path := _slug || '-' || _tid || '/' || _slug || '-' || _vid || '.m4a';
+  return next;
+end $$;
+
+-- Client uploads to upload_path, then passes getPublicUrl(path).data.publicUrl here.
+create or replace function public.set_version_file(_version_id uuid, _resource_url text)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  update public.versions set resource_url = _resource_url where id = _version_id;
+end $$;
+
+create or replace function public.update_version(
+  _version_id uuid, _name text, _status public.version_status, _release_date date
+) returns public.versions
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _v public.versions;
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  update public.versions set name=_name, status=_status, release_date=_release_date
+    where id=_version_id returning * into _v;
+  return _v;
+end $$;
+
+create or replace function public.delete_version(_version_id uuid)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  delete from public.track_versions where version_id = _version_id;
+  delete from public.versions where id = _version_id;
+end $$;
+
+revoke all on function
+  public.create_version(uuid,text,public.version_status,date),
+  public.set_version_file(uuid,text),
+  public.update_version(uuid,text,public.version_status,date),
+  public.delete_version(uuid)
+  from public;
+grant execute on function
+  public.create_version(uuid,text,public.version_status,date),
+  public.set_version_file(uuid,text),
+  public.update_version(uuid,text,public.version_status,date),
+  public.delete_version(uuid)
+  to authenticated;

--- a/supabase/migrations/20260712000900_rpc_genres.sql
+++ b/supabase/migrations/20260712000900_rpc_genres.sql
@@ -1,0 +1,19 @@
+-- Any authenticated artist_member may extend the genre vocabulary.
+
+create or replace function public.create_genre(_name text)
+  returns public.genres
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _g public.genres;
+begin
+  if not exists (select 1 from public.artist_members where user_id = auth.uid()) then
+    raise exception 'only artist members may create genres' using errcode = '42501';
+  end if;
+  insert into public.genres (name) values (_name)
+    on conflict (name) do update set name = excluded.name
+    returning * into _g;
+  return _g;
+end $$;
+
+revoke all on function public.create_genre(text) from public;
+grant execute on function public.create_genre(text) to authenticated;

--- a/supabase/migrations/20260712001000_storage_policies.sql
+++ b/supabase/migrations/20260712001000_storage_policies.sql
@@ -1,0 +1,40 @@
+-- Member-only write policies on the versions (audio) and covers buckets.
+-- Both buckets already exist and are public.
+
+update storage.buckets set public = true where id in ('versions','covers');
+
+-- Helper: is the caller a member of ANY artist? (coarse; tighten to per-artist
+-- path parsing when the platform opens up — spec §7.)
+create or replace function public.is_any_artist_member()
+  returns boolean language sql security definer set search_path = public, pg_temp stable
+as $$
+  select exists (select 1 from public.artist_members where user_id = auth.uid());
+$$;
+grant execute on function public.is_any_artist_member() to authenticated, anon;
+
+-- Clean up any earlier policies that targeted a mis-named 'songs' bucket.
+drop policy if exists "members write songs"  on storage.objects;
+drop policy if exists "members update songs" on storage.objects;
+drop policy if exists "members delete songs" on storage.objects;
+
+-- versions bucket (audio)
+drop policy if exists "members write versions" on storage.objects;
+create policy "members write versions" on storage.objects for insert to authenticated
+  with check (bucket_id = 'versions' and public.is_any_artist_member());
+drop policy if exists "members update versions" on storage.objects;
+create policy "members update versions" on storage.objects for update to authenticated
+  using (bucket_id = 'versions' and public.is_any_artist_member());
+drop policy if exists "members delete versions" on storage.objects;
+create policy "members delete versions" on storage.objects for delete to authenticated
+  using (bucket_id = 'versions' and public.is_any_artist_member());
+
+-- covers bucket
+drop policy if exists "members write covers" on storage.objects;
+create policy "members write covers" on storage.objects for insert to authenticated
+  with check (bucket_id = 'covers' and public.is_any_artist_member());
+drop policy if exists "members update covers" on storage.objects;
+create policy "members update covers" on storage.objects for update to authenticated
+  using (bucket_id = 'covers' and public.is_any_artist_member());
+drop policy if exists "members delete covers" on storage.objects;
+create policy "members delete covers" on storage.objects for delete to authenticated
+  using (bucket_id = 'covers' and public.is_any_artist_member());


### PR DESCRIPTION
## Summary

Complete artist content-management feature, replacing the painful manual dashboard workflow for publishing songs. Built in two plans on one branch.

**Plan 1 — API foundation (database + storage):**
- **Roles layer:** `artist_members(artist_id, user_id, role owner|maintainer)` + `is_artist_member()` guard; `albums.artist_id` added and backfilled to Bohns.
- **Genres:** `genres` + `album_genres` (m2m) with an auto `slugify` trigger.
- **Setlist ordering:** `album_tracks.position` added and backfilled.
- **Write lockdown:** content tables keep public read with **no** client write policies — all mutations go through `SECURITY DEFINER` RPCs that check membership first (no service-role key anywhere).
- **RPC surface:** album CRUD (+ genres/cover), track CRUD + `reorder_setlist`, version create/finalize/update/delete (create returns the deterministic `{track.slug}-{track.id}/{track.slug}-{version.id}.m4a` upload path), `create_genre`.
- **Storage:** member-only write policies on the `versions` (audio) and `covers` buckets.

**Plan 2 — inline edit UI:**
- Member-gated **Edit** mode on the album page (`canEdit` computed client-side from `artist_members`; every write also guarded server-side by the RPCs).
- Editable **name / description / type**, **genre** chip combobox (search + create), click-to-replace **cover** upload.
- **Setlist** editing — up/down move, add, remove (staged, committed on **Save**; explicit Save/Cancel).
- Per-track **versions** panel — list, add-with-audio-upload, change status, delete (immediate).
- No new dependencies (reorder via up/down controls). Mirrors the existing `LikesProvider` client-context pattern.

Design spec: `docs/superpowers/specs/2026-07-12-artist-content-management-design.md`
Plans: `docs/superpowers/plans/2026-07-12-artist-content-api-foundation.md`, `docs/superpowers/plans/2026-07-12-inline-edit-ui.md`

## Test Plan

- [x] **DB layer:** all 10 migrations applied to prod and verified via per-task rollback `DO`-block assertions (member vs non-member); end-to-end smoke test passed. Direct client writes denied by RLS.
- [x] **UI:** `tsc --noEmit` + `next build` compile/type-check clean; each task manually verified in-app signed in as the Bohns owner — edit toggle, field/genre/cover edits, setlist move/add/remove with Save/Cancel, and audio upload end-to-end (version plays after upload). Signed-out users see no edit affordances.

## Notes / follow-ups

- Storage write policy is intentionally coarse ("any artist member") for the single-artist phase; tighten to per-artist path parsing when the platform opens up.
- Discovered during execution: audio bucket id is `versions` (not `songs`); a trigger already syncs `versions.track_id` ↔ `track_versions`; the artist row is named `Bohns`.
- Deferred by design: creating a brand-new album from zero, Works/variants, per-track cover editing, storage GC on version delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)