### PR TITLE
Slide the vinyl out of the cover when an album is active

### DIFF
--- a/src/components/AlbumCard.module.css
+++ b/src/components/AlbumCard.module.css
@@ -7,6 +7,12 @@
   gap: 24px;
 }
 
+/* Slide the vinyl out while the cover is hovered or keyboard-focused. */
+.coverLink:hover,
+.coverLink:focus-visible {
+  --extract: 1;
+}
+
 .description {
   color: var(--album-light);
   font-size: 16px;

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { AlbumWithTracks } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
-import AlbumCover from "./AlbumCover";
+import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumHeader from "./AlbumHeader";
 import AlbumMetaTiles from "./AlbumMetaTiles";
 import AlbumPlaylist from "./AlbumPlaylist";
@@ -14,7 +14,12 @@ export default function AlbumCard({ album }: { album: AlbumWithTracks }) {
   return (
     <article className={styles.card} style={paletteVars(palette)}>
       <Link href={`/albums/${album.id}`} aria-label={album.name}>
-        <AlbumCover coverUrl={album.cover_url} alt={album.name} size={160} />
+        <AlbumCoverLive
+          albumId={album.id}
+          coverUrl={album.cover_url}
+          alt={album.name}
+          size={160}
+        />
       </Link>
       <AlbumHeader album={album} align="center" linked />
       <AlbumMetaTiles

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -13,7 +13,11 @@ export default function AlbumCard({ album }: { album: AlbumWithTracks }) {
 
   return (
     <article className={styles.card} style={paletteVars(palette)}>
-      <Link href={`/albums/${album.id}`} aria-label={album.name}>
+      <Link
+        href={`/albums/${album.id}`}
+        aria-label={album.name}
+        className={styles.coverLink}
+      >
         <AlbumCoverLive
           albumId={album.id}
           coverUrl={album.cover_url}

--- a/src/components/AlbumCover.module.css
+++ b/src/components/AlbumCover.module.css
@@ -1,8 +1,21 @@
 .cover {
+  /* Tunable geometry, all as a fraction of --size (the square cover). */
+  --vinyl: 0.94; /* vinyl diameter */
+  --peek: 0.16; /* resting: vinyl overhang beyond the cover's right edge */
+  --slide: 0.46; /* active: extra rightward slide (~66% of the disc exposed) */
+  --tilt: 2deg; /* active: cover rotation */
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+
   position: relative;
-  width: calc(var(--size) * 1.16);
+  width: calc(var(--size) * (1 + var(--peek)));
   height: var(--size);
   flex-shrink: 0;
+}
+
+/* Reserve room for the fully extracted vinyl (contexts with content to the
+   right of the cover). Without it the vinyl simply overflows when active. */
+.reserve {
+  width: calc(var(--size) * (1 + var(--peek) + var(--slide)));
 }
 
 .wrap {
@@ -14,7 +27,13 @@
     calc(var(--size) * 0.1) calc(var(--size) * 0.05);
   overflow: hidden;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  transform-origin: center;
+  transition: transform 0.55s var(--ease);
   z-index: 1;
+}
+
+.active .wrap {
+  transform: rotate(var(--tilt));
 }
 
 .wrap img {
@@ -44,13 +63,25 @@
 .vinyl {
   position: absolute;
   top: 50%;
-  right: 0;
-  translate: 0 -50%;
-  width: calc(var(--size) * 0.94);
+  left: calc(var(--size) * (1 + var(--peek) - var(--vinyl)));
+  width: calc(var(--size) * var(--vinyl));
   aspect-ratio: 1;
+  transform: translateY(-50%);
+  transition: transform 0.55s var(--ease);
   z-index: 0;
+}
+
+.active .vinyl {
+  transform: translateY(-50%) translateX(calc(var(--size) * var(--slide)));
 }
 
 .vinyl img {
   object-fit: contain;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wrap,
+  .vinyl {
+    transition: none;
+  }
 }

--- a/src/components/AlbumCover.module.css
+++ b/src/components/AlbumCover.module.css
@@ -3,7 +3,7 @@
   --vinyl: 0.94; /* vinyl diameter */
   --peek: 0.16; /* resting: vinyl overhang beyond the cover's right edge */
   --slide: 0.46; /* active: extra rightward slide (~66% of the disc exposed) */
-  --tilt: 2deg; /* active: cover rotation */
+  --tilt: -2deg; /* active: cover rotation */
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 
   position: relative;

--- a/src/components/AlbumCover.module.css
+++ b/src/components/AlbumCover.module.css
@@ -30,6 +30,13 @@
   transform-origin: center;
   transition: transform 0.55s var(--ease);
   z-index: 1;
+  /* Palette-coloured backdrop so the cover never shows through (to the vinyl
+     behind it) while the artwork is still loading. */
+  background: linear-gradient(
+    135deg,
+    var(--album-deep),
+    color-mix(in srgb, var(--album-accent) 40%, var(--bg))
+  );
 }
 
 .active .wrap {
@@ -48,16 +55,6 @@
   mix-blend-mode: multiply;
   opacity: 0.6;
   pointer-events: none;
-}
-
-.placeholder {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    135deg,
-    var(--album-deep),
-    color-mix(in srgb, var(--album-accent) 40%, var(--bg))
-  );
 }
 
 .vinyl {

--- a/src/components/AlbumCover.module.css
+++ b/src/components/AlbumCover.module.css
@@ -18,6 +18,13 @@
   width: calc(var(--size) * (1 + var(--peek) + var(--slide)));
 }
 
+/* --extract (0 resting → 1 extracted) drives the cover tilt and vinyl slide.
+   Set here by the active state; a hovered ancestor (album card / nav item)
+   can also set it, since custom properties inherit into the cover. */
+.active {
+  --extract: 1;
+}
+
 .wrap {
   position: absolute;
   inset: 0 auto 0 0;
@@ -28,6 +35,7 @@
   overflow: hidden;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
   transform-origin: center;
+  transform: rotate(calc(var(--extract, 0) * var(--tilt)));
   transition: transform 0.55s var(--ease);
   z-index: 1;
   /* Palette-coloured backdrop so the cover never shows through (to the vinyl
@@ -37,10 +45,6 @@
     var(--album-deep),
     color-mix(in srgb, var(--album-accent) 40%, var(--bg))
   );
-}
-
-.active .wrap {
-  transform: rotate(var(--tilt));
 }
 
 .wrap img {
@@ -63,13 +67,10 @@
   left: calc(var(--size) * (1 + var(--peek) - var(--vinyl)));
   width: calc(var(--size) * var(--vinyl));
   aspect-ratio: 1;
-  transform: translateY(-50%);
+  transform: translateY(-50%)
+    translateX(calc(var(--extract, 0) * var(--size) * var(--slide)));
   transition: transform 0.55s var(--ease);
   z-index: 0;
-}
-
-.active .vinyl {
-  transform: translateY(-50%) translateX(calc(var(--size) * var(--slide)));
 }
 
 .vinyl img {

--- a/src/components/AlbumCover.tsx
+++ b/src/components/AlbumCover.tsx
@@ -8,12 +8,35 @@ type Props = {
   /** Rendered size (px) of the square cover; the vinyl adds ~16% width. */
   size: number;
   priority?: boolean;
+  /**
+   * Active state (album playing or on its page): the cover tilts and the vinyl
+   * slides out from behind it. Defaults to the tucked-in resting state.
+   */
+  active?: boolean;
+  /**
+   * Reserve layout width for the extracted vinyl. Use in contexts with content
+   * to the right of the cover (album header, switcher) so it isn't overlapped.
+   */
+  reserve?: boolean;
 };
 
-export default function AlbumCover({ coverUrl, alt, size, priority }: Props) {
+export default function AlbumCover({
+  coverUrl,
+  alt,
+  size,
+  priority,
+  active = false,
+  reserve = false,
+}: Props) {
   return (
     <div
-      className={styles.cover}
+      className={[
+        styles.cover,
+        active ? styles.active : "",
+        reserve ? styles.reserve : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       style={{ "--size": `${size}px` } as CSSProperties}
     >
       <div className={styles.vinyl}>

--- a/src/components/AlbumCover.tsx
+++ b/src/components/AlbumCover.tsx
@@ -43,7 +43,7 @@ export default function AlbumCover({
         <Image src="/vinyl.png" alt="" fill sizes={`${size}px`} />
       </div>
       <div className={styles.wrap}>
-        {coverUrl ? (
+        {coverUrl && (
           <Image
             src={coverUrl}
             alt={alt}
@@ -51,8 +51,6 @@ export default function AlbumCover({
             sizes={`${size}px`}
             priority={priority}
           />
-        ) : (
-          <div className={styles.placeholder} />
         )}
         <div className={styles.texture} />
       </div>

--- a/src/components/AlbumCoverLive.tsx
+++ b/src/components/AlbumCoverLive.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { usePlayer } from "@/player/PlayerProvider";
 import AlbumCover from "./AlbumCover";
@@ -16,13 +17,25 @@ type Props = {
 /**
  * AlbumCover wired to the app's live state: the vinyl slides out of the cover
  * when this album is playing, or when we're on its page (menu item + header).
+ *
+ * The cover paints in its resting state first, then flips to active one frame
+ * after mount, so an already-active cover plays the slide-out as an entrance
+ * animation on load rather than appearing pre-extracted.
  */
 export default function AlbumCoverLive({ albumId, ...cover }: Props) {
   const pathname = usePathname();
   const { current, isPlaying } = usePlayer();
 
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   const onAlbumPage = pathname === `/albums/${albumId}`;
   const playingThisAlbum = current?.albumId === albumId && isPlaying;
 
-  return <AlbumCover active={onAlbumPage || playingThisAlbum} {...cover} />;
+  return (
+    <AlbumCover active={entered && (onAlbumPage || playingThisAlbum)} {...cover} />
+  );
 }

--- a/src/components/AlbumCoverLive.tsx
+++ b/src/components/AlbumCoverLive.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { usePlayer } from "@/player/PlayerProvider";
+import AlbumCover from "./AlbumCover";
+
+type Props = {
+  albumId: string;
+  coverUrl: string | null;
+  alt: string;
+  size: number;
+  priority?: boolean;
+  reserve?: boolean;
+};
+
+/**
+ * AlbumCover wired to the app's live state: the vinyl slides out of the cover
+ * when this album is playing, or when we're on its page (menu item + header).
+ */
+export default function AlbumCoverLive({ albumId, ...cover }: Props) {
+  const pathname = usePathname();
+  const { current, isPlaying } = usePlayer();
+
+  const onAlbumPage = pathname === `/albums/${albumId}`;
+  const playingThisAlbum = current?.albumId === albumId && isPlaying;
+
+  return <AlbumCover active={onAlbumPage || playingThisAlbum} {...cover} />;
+}

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -2,7 +2,7 @@
 
 import type { AlbumWithTracks, TrackLyrics } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
-import AlbumCover from "./AlbumCover";
+import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumHeader from "./AlbumHeader";
 import AlbumInfos from "./AlbumInfos";
 import AlbumMetaTiles from "./AlbumMetaTiles";
@@ -40,11 +40,13 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
             size={165}
           />
         ) : (
-          <AlbumCover
+          <AlbumCoverLive
+            albumId={album.id}
             coverUrl={album.cover_url}
             alt={album.name}
             size={165}
             priority
+            reserve
           />
         )}
         <div className={styles.heroBody}>

--- a/src/components/AlbumSwitcher.module.css
+++ b/src/components/AlbumSwitcher.module.css
@@ -12,8 +12,11 @@
   transition: opacity 0.15s ease;
 }
 
-.item:hover {
+.item:hover,
+.item:focus-visible {
   opacity: 0.66;
+  /* Slide the vinyl out of the hovered nav item's cover. */
+  --extract: 1;
 }
 
 .active,

--- a/src/components/AlbumSwitcher.tsx
+++ b/src/components/AlbumSwitcher.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { AlbumWithTracks } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
-import AlbumCover from "./AlbumCover";
+import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumInfos from "./AlbumInfos";
 import styles from "./AlbumSwitcher.module.css";
 
@@ -29,7 +29,13 @@ export default function AlbumSwitcher({ albums, activeId }: Props) {
             aria-current={active ? "page" : undefined}
             style={paletteVars(getPalette(album))}
           >
-            <AlbumCover coverUrl={album.cover_url} alt="" size={67} />
+            <AlbumCoverLive
+              albumId={album.id}
+              coverUrl={album.cover_url}
+              alt=""
+              size={67}
+              reserve
+            />
             <span className={styles.text}>
               <span className={styles.name}>{album.name}</span>
               <AlbumInfos tracks={album.tracks} />


### PR DESCRIPTION
Add two states to AlbumCover: a resting state (vinyl tucked behind the
cover, peeking on the right) and an active state where the cover tilts ~2°
and the vinyl slides out so ~66% of the disc is exposed, with a smooth
one-time transition between them.

A new AlbumCoverLive client wrapper marks a cover active when its album is
playing or when we're on its page, so the effect shows on home cards, the
album-page header, and the switcher menu item.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SeMy7NpCvK8zrgMdbFN8Hy