### PR TITLE
Move audio duration from client-side sniffing to server storage

### DIFF
--- a/scripts/backfill-version-durations.mjs
+++ b/scripts/backfill-version-durations.mjs
@@ -6,10 +6,15 @@
 // New uploads already store their duration (set_version_file). This walks the
 // rows still missing it, reads each file's length, and writes it back.
 //
-// Usage:
-//   NEXT_PUBLIC_SUPABASE_URL=... \
-//   SUPABASE_SERVICE_ROLE_KEY=... \
-//   node scripts/backfill-version-durations.mjs
+// Credentials are read from the environment, or from a .env.local / .env file
+// in the repo root (both are git-ignored) so you don't have to pass them inline
+// — inline `VAR=value` prefixes are silently ignored on Windows shells.
+//
+//   1. Put these two lines in .env.local (NEXT_PUBLIC_SUPABASE_URL may already
+//      be there):
+//        NEXT_PUBLIC_SUPABASE_URL=https://YOURPROJECT.supabase.co
+//        SUPABASE_SERVICE_ROLE_KEY=your-service-role-secret
+//   2. node scripts/backfill-version-durations.mjs
 //
 // The service-role key bypasses RLS to update versions directly; keep it out of
 // the browser and out of git. Re-runnable: it only touches rows where
@@ -17,14 +22,39 @@
 // from the MP4 `mvhd` atom (no external tools or npm deps). Anything that
 // doesn't parse is logged and left null for a manual pass.
 
+import { readFileSync } from "node:fs";
 import { createClient } from "@supabase/supabase-js";
+
+// Best-effort load of .env.local then .env (real env vars still win). Minimal
+// parser: KEY=VALUE lines, ignores blanks/comments, strips surrounding quotes.
+for (const file of [".env.local", ".env"]) {
+  let text;
+  try {
+    text = readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
+  } catch {
+    continue;
+  }
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\s*([\w.]+)\s*=\s*(.*)\s*$/);
+    if (!m || line.trimStart().startsWith("#")) continue;
+    const name = m[1];
+    const value = m[2].replace(/^(['"])(.*)\1$/, "$2");
+    if (process.env[name] === undefined) process.env[name] = value;
+  }
+}
 
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!url || !key) {
+  const missing = [
+    !url && "NEXT_PUBLIC_SUPABASE_URL",
+    !key && "SUPABASE_SERVICE_ROLE_KEY",
+  ].filter(Boolean);
   console.error(
-    "Missing env. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY."
+    `Missing ${missing.join(" and ")}.\n` +
+      "Add it to .env.local in the repo root (see the header of this file), " +
+      "or export it in your shell, then re-run."
   );
   process.exit(1);
 }

--- a/scripts/backfill-version-durations.mjs
+++ b/scripts/backfill-version-durations.mjs
@@ -6,15 +6,19 @@
 // New uploads already store their duration (set_version_file). This walks the
 // rows still missing it, reads each file's length, and writes it back.
 //
-// Credentials are read from the environment, or from a .env.local / .env file
-// in the repo root (both are git-ignored) so you don't have to pass them inline
-// — inline `VAR=value` prefixes are silently ignored on Windows shells.
+// Provide the Supabase URL and service-role key any one of these ways — the
+// simplest and most shell-proof is the first (arguments work identically on
+// macOS, Linux, and every Windows shell):
 //
-//   1. Put these two lines in .env.local (NEXT_PUBLIC_SUPABASE_URL may already
-//      be there):
+//   A. As arguments:
+//        node scripts/backfill-version-durations.mjs <URL> <SERVICE_ROLE_KEY>
+//
+//   B. In .env.local / .env at the repo root (both git-ignored):
 //        NEXT_PUBLIC_SUPABASE_URL=https://YOURPROJECT.supabase.co
 //        SUPABASE_SERVICE_ROLE_KEY=your-service-role-secret
-//   2. node scripts/backfill-version-durations.mjs
+//      then: node scripts/backfill-version-durations.mjs
+//
+//   C. As real environment variables you exported in the shell.
 //
 // The service-role key bypasses RLS to update versions directly; keep it out of
 // the browser and out of git. Re-runnable: it only touches rows where
@@ -23,38 +27,59 @@
 // doesn't parse is logged and left null for a manual pass.
 
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createClient } from "@supabase/supabase-js";
 
 // Best-effort load of .env.local then .env (real env vars still win). Minimal
-// parser: KEY=VALUE lines, ignores blanks/comments, strips surrounding quotes.
+// parser: KEY=VALUE lines, ignores blanks/comments, strips surrounding quotes
+// and a UTF-8 BOM. Records where it looked, for the diagnostic below.
+const envFiles = [];
 for (const file of [".env.local", ".env"]) {
+  const path = fileURLToPath(new URL(`../${file}`, import.meta.url));
   let text;
   try {
-    text = readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
+    text = readFileSync(path, "utf8");
   } catch {
+    envFiles.push({ file, path, found: false, keys: [] });
     continue;
   }
-  for (const line of text.split("\n")) {
-    const m = line.match(/^\s*([\w.]+)\s*=\s*(.*)\s*$/);
-    if (!m || line.trimStart().startsWith("#")) continue;
+  const keys = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.replace(/^﻿/, "").replace(/\r$/, "");
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const m = line.match(/^\s*([\w.]+)\s*=\s*(.*?)\s*$/);
+    if (!m) continue;
     const name = m[1];
     const value = m[2].replace(/^(['"])(.*)\1$/, "$2");
+    keys.push(name);
     if (process.env[name] === undefined) process.env[name] = value;
   }
+  envFiles.push({ file, path, found: true, keys });
 }
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const [argUrl, argKey] = process.argv.slice(2);
+const url =
+  argUrl || process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const key = argKey || process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!url || !key) {
   const missing = [
     !url && "NEXT_PUBLIC_SUPABASE_URL",
     !key && "SUPABASE_SERVICE_ROLE_KEY",
   ].filter(Boolean);
+  console.error(`\nMissing ${missing.join(" and ")}.\n`);
+  console.error("Where I looked for a .env file:");
+  for (const e of envFiles) {
+    console.error(
+      e.found
+        ? `  • ${e.path} — found, keys: ${e.keys.join(", ") || "(none parsed)"}`
+        : `  • ${e.path} — not found`
+    );
+  }
   console.error(
-    `Missing ${missing.join(" and ")}.\n` +
-      "Add it to .env.local in the repo root (see the header of this file), " +
-      "or export it in your shell, then re-run."
+    "\nQuickest fix — pass them as arguments (works in any shell):\n" +
+      "  node scripts/backfill-version-durations.mjs " +
+      '"https://YOURPROJECT.supabase.co" "your-service-role-key"\n'
   );
   process.exit(1);
 }

--- a/scripts/backfill-version-durations.mjs
+++ b/scripts/backfill-version-durations.mjs
@@ -1,0 +1,139 @@
+// One-time backfill: compute `duration_seconds` for existing versions that
+// predate on-upload duration capture, so the app can show track/album times
+// without the browser sniffing every audio file (the cause of the album/home
+// pages' infinite loading, device heat, and iOS crash loops).
+//
+// New uploads already store their duration (set_version_file). This walks the
+// rows still missing it, reads each file's length, and writes it back.
+//
+// Usage:
+//   NEXT_PUBLIC_SUPABASE_URL=... \
+//   SUPABASE_SERVICE_ROLE_KEY=... \
+//   node scripts/backfill-version-durations.mjs
+//
+// The service-role key bypasses RLS to update versions directly; keep it out of
+// the browser and out of git. Re-runnable: it only touches rows where
+// duration_seconds is null. Files are uploaded as .m4a, so duration is read
+// from the MP4 `mvhd` atom (no external tools or npm deps). Anything that
+// doesn't parse is logged and left null for a manual pass.
+
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error(
+    "Missing env. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY."
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(url, key, { auth: { persistSession: false } });
+
+/**
+ * Duration (seconds) from an MP4/M4A buffer, read from the movie header
+ * (`moov` › `mvhd`: timescale + duration). Returns null if not an MP4 or the
+ * atom is absent. Scans boxes without decoding audio.
+ */
+function mp4Duration(buf) {
+  // Find the `moov` container among the top-level boxes.
+  const moov = findBox(buf, 0, buf.length, "moov");
+  if (!moov) return null;
+  const mvhd = findBox(buf, moov.start, moov.end, "mvhd");
+  if (!mvhd) return null;
+
+  let p = mvhd.start; // points at the mvhd payload
+  const version = buf[p];
+  p += 4; // version (1) + flags (3)
+  let timescale;
+  let duration;
+  if (version === 1) {
+    p += 8 + 8; // creation + modification time (64-bit each)
+    timescale = buf.readUInt32BE(p);
+    p += 4;
+    duration = Number(buf.readBigUInt64BE(p));
+  } else {
+    p += 4 + 4; // creation + modification time (32-bit each)
+    timescale = buf.readUInt32BE(p);
+    p += 4;
+    duration = buf.readUInt32BE(p);
+  }
+  if (!timescale || !Number.isFinite(duration)) return null;
+  return duration / timescale;
+}
+
+/**
+ * Locate a direct child box by type within [from, to). Returns the payload
+ * range { start, end }, i.e. just past the 8- (or 16-) byte box header.
+ */
+function findBox(buf, from, to, type) {
+  let p = from;
+  while (p + 8 <= to) {
+    let size = buf.readUInt32BE(p);
+    const boxType = buf.toString("ascii", p + 4, p + 8);
+    let header = 8;
+    if (size === 1) {
+      // 64-bit largesize
+      size = Number(buf.readBigUInt64BE(p + 8));
+      header = 16;
+    } else if (size === 0) {
+      // extends to end of the enclosing range
+      size = to - p;
+    }
+    if (size < header) return null; // malformed
+    if (boxType === type) return { start: p + header, end: p + size };
+    p += size;
+  }
+  return null;
+}
+
+async function main() {
+  const { data: rows, error } = await supabase
+    .from("versions")
+    .select("id,resource_url")
+    .is("duration_seconds", null)
+    .not("resource_url", "is", null);
+  if (error) throw new Error(error.message);
+
+  if (!rows || rows.length === 0) {
+    console.log("Nothing to backfill — all versions already have a duration.");
+    return;
+  }
+
+  console.log(`Backfilling ${rows.length} version(s)…`);
+  let ok = 0;
+  let skipped = 0;
+  for (const row of rows) {
+    try {
+      const res = await fetch(row.resource_url);
+      if (!res.ok) {
+        console.warn(`✗ ${row.id}: fetch ${res.status}`);
+        skipped++;
+        continue;
+      }
+      const seconds = mp4Duration(Buffer.from(await res.arrayBuffer()));
+      if (seconds == null) {
+        console.warn(`✗ ${row.id}: could not read duration (not m4a?)`);
+        skipped++;
+        continue;
+      }
+      const { error: upErr } = await supabase
+        .from("versions")
+        .update({ duration_seconds: seconds })
+        .eq("id", row.id);
+      if (upErr) throw new Error(upErr.message);
+      console.log(`✓ ${row.id} → ${seconds.toFixed(1)}s`);
+      ok++;
+    } catch (err) {
+      console.warn(`✗ ${row.id}: ${err.message}`);
+      skipped++;
+    }
+  }
+  console.log(`\nDone. Updated ${ok}, skipped ${skipped}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/AlbumInfos.tsx
+++ b/src/components/AlbumInfos.tsx
@@ -1,16 +1,19 @@
-"use client";
-
-import { useTotalDuration } from "@/player/durations";
 import type { Track } from "@/lib/types";
 import styles from "./AlbumInfos.module.css";
 
-/** "N songs · M min" line — duration appears once audio metadata resolves. */
+/** "N songs · M min" line — the minutes appear once every playable track has a
+    known duration (server-provided; null while a version is still unmeasured). */
 export default function AlbumInfos({ tracks }: { tracks: Track[] }) {
-  const total = useTotalDuration(tracks.map((t) => t.latest_resource_url));
-
   const count = tracks.length;
   const songs = `${count} ${count === 1 ? "song" : "songs"}`;
-  const minutes = total !== null ? ` · ${Math.max(1, Math.round(total / 60))} min` : "";
+
+  const playable = tracks.filter((t) => t.latest_resource_url);
+  const measured = playable.every((t) => typeof t.duration === "number");
+  const total = measured
+    ? playable.reduce((sum, t) => sum + (t.duration ?? 0), 0)
+    : null;
+  const minutes =
+    total !== null ? ` · ${Math.max(1, Math.round(total / 60))} min` : "";
 
   return (
     <p className={styles.infos}>

--- a/src/components/AlbumTrack.tsx
+++ b/src/components/AlbumTrack.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Mic, Pause, Play } from "lucide-react";
 import { toPlayerTrack, usePlayer } from "@/player/PlayerProvider";
-import { formatTime, useDuration } from "@/player/durations";
+import { formatTime } from "@/player/durations";
 import type { Track } from "@/lib/types";
 import LikeButton from "./LikeButton";
 import LyricsSheet from "./LyricsSheet";
@@ -24,7 +24,7 @@ export default function AlbumTrack({
   lyrics = null,
 }: Props) {
   const { current, isPlaying, toggle, playFrom } = usePlayer();
-  const duration = useDuration(track.latest_resource_url);
+  const duration = track.duration;
   const [lyricsOpen, setLyricsOpen] = useState(false);
 
   const playable = Boolean(track.latest_resource_url);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -11,6 +11,47 @@ function fail(context: string, error: { message?: string }): never {
 const TRACK_COLS =
   "track_id,track_name,track_description,album_id,album_name,album_cover_url,latest_version_id,latest_status,latest_resource_url,latest_release_date,like_count";
 
+/**
+ * Fill in each track's `duration` from `versions.duration_seconds`, keyed on
+ * the latest version id the overview already carries. One batched query keeps
+ * this cheap; duration is non-critical, so a failure degrades to null (the UI
+ * simply omits the time) rather than breaking the page.
+ */
+async function attachDurations(
+  client: SupabaseClient,
+  tracks: Track[]
+): Promise<void> {
+  const ids = [
+    ...new Set(
+      tracks
+        .map((t) => t.latest_version_id)
+        .filter((id): id is string => Boolean(id))
+    ),
+  ];
+  let byId = new Map<string, number | null>();
+  if (ids.length > 0) {
+    const { data, error } = await client
+      .from("versions")
+      .select("id,duration_seconds")
+      .in("id", ids);
+    if (error) {
+      console.error("Failed to load track durations", error.message);
+    } else {
+      byId = new Map(
+        (data ?? []).map((row) => [
+          row.id as string,
+          (row.duration_seconds as number | null) ?? null,
+        ])
+      );
+    }
+  }
+  for (const track of tracks) {
+    track.duration = track.latest_version_id
+      ? byId.get(track.latest_version_id) ?? null
+      : null;
+  }
+}
+
 function groupTracks(albums: Album[], tracks: Track[]): AlbumWithTracks[] {
   const byAlbum = new Map<string, Track[]>();
   for (const track of tracks) {
@@ -42,10 +83,9 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
   if (albumsRes.error) fail("Failed to load albums", albumsRes.error);
   if (tracksRes.error) fail("Failed to load tracks", tracksRes.error);
 
-  return groupTracks(
-    (albumsRes.data ?? []) as Album[],
-    (tracksRes.data ?? []) as Track[]
-  );
+  const tracks = (tracksRes.data ?? []) as Track[];
+  await attachDurations(supabase, tracks);
+  return groupTracks((albumsRes.data ?? []) as Album[], tracks);
 }
 
 export async function getAlbumWithTracks(
@@ -80,6 +120,7 @@ export async function getAlbumWithTracks(
     .map((row) => (row as unknown as { genres: Genre | null }).genres)
     .filter((g): g is Genre => Boolean(g));
 
+  await attachDurations(supabase, tracks);
   return { ...(albumRes.data as Album), tracks, genres };
 }
 
@@ -133,7 +174,9 @@ export async function getLikedTracks(
   const byId = new Map(
     ((tracks ?? []) as Track[]).map((track) => [track.track_id, track])
   );
-  return likedIds
+  const ordered = likedIds
     .map((id) => byId.get(id))
     .filter((track): track is Track => Boolean(track));
+  await attachDurations(client, ordered);
+  return ordered;
 }

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -283,13 +283,16 @@ export async function uploadVersionAudio(
 }
 
 /** Upload to the versions bucket and record a cache-busted public URL —
-    the CDN keys on the query string, so replaced audio is fetched fresh. */
+    the CDN keys on the query string, so replaced audio is fetched fresh. The
+    audio length is measured once, here, from the local file so the app can
+    show track/album times without every client re-sniffing them at render. */
 async function uploadToPath(
   path: string,
   versionId: string,
   file: File
 ): Promise<void> {
   const supabase = createClient();
+  const duration = await audioDurationFromFile(file);
   const up = await supabase.storage
     .from("versions")
     .upload(path, file, { upsert: true });
@@ -300,8 +303,31 @@ async function uploadToPath(
   const { error } = await supabase.rpc("set_version_file", {
     _version_id: versionId,
     _resource_url: `${base}?v=${Date.now()}`,
+    _duration: duration,
   });
   if (error) throw new Error(error.message);
+}
+
+/** Read an audio file's duration in the browser from a local object URL (no
+    network — it decodes the file the user just picked). Best-effort: a decode
+    failure resolves to null and never blocks the upload. */
+function audioDurationFromFile(file: File): Promise<number | null> {
+  if (typeof Audio === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const audio = new Audio();
+    audio.preload = "metadata";
+    const finish = (value: number | null) => {
+      URL.revokeObjectURL(url);
+      resolve(value);
+    };
+    audio.addEventListener("loadedmetadata", () => {
+      const d = audio.duration;
+      finish(Number.isFinite(d) && d > 0 ? d : null);
+    });
+    audio.addEventListener("error", () => finish(null));
+    audio.src = url;
+  });
 }
 
 /** Storage object path from a `versions` bucket public URL (query stripped). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,12 @@ export type Track = {
   latest_resource_url: string | null;
   latest_release_date: string | null;
   like_count: number | null;
+  /**
+   * Playback length (seconds) of the latest version. Populated by the data
+   * layer from `versions.duration_seconds`; null until it has been computed
+   * (on upload, or by the backfill script for pre-existing rows).
+   */
+  duration: number | null;
 };
 
 export type AlbumWithTracks = Album & {

--- a/src/player/durations.ts
+++ b/src/player/durations.ts
@@ -1,105 +1,11 @@
-"use client";
-
-import { useEffect, useState } from "react";
-
 /**
- * Durations are not stored in Supabase (step 1), so they are resolved
- * client-side by preloading audio metadata. Results are cached per URL and
- * requests run through a small queue to avoid opening every connection at
- * once.
+ * Track/album durations come from the server (`versions.duration_seconds`,
+ * surfaced on each Track by the data layer). They used to be sniffed in the
+ * browser by loading every track's audio metadata, which flooded the album and
+ * home pages with media requests — infinite loading spinners, device heat,
+ * hijacked audio sessions, and iOS WebContent OOM crashes. This module now only
+ * formats a duration for display.
  */
-
-const cache = new Map<string, Promise<number>>();
-
-const MAX_CONCURRENT = 4;
-let active = 0;
-const queue: Array<() => void> = [];
-
-function next() {
-  if (active >= MAX_CONCURRENT) return;
-  const run = queue.shift();
-  if (run) run();
-}
-
-function loadDuration(url: string): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const start = () => {
-      active++;
-      const audio = new Audio();
-      audio.preload = "metadata";
-      const done = (fn: () => void) => {
-        active--;
-        fn();
-        audio.src = "";
-        next();
-      };
-      audio.addEventListener("loadedmetadata", () => {
-        const duration = audio.duration;
-        done(() => resolve(duration));
-      });
-      audio.addEventListener("error", () =>
-        done(() => reject(new Error(`Could not load metadata for ${url}`)))
-      );
-      audio.src = url;
-    };
-    queue.push(start);
-    next();
-  });
-}
-
-export function getDuration(url: string): Promise<number> {
-  let promise = cache.get(url);
-  if (!promise) {
-    promise = loadDuration(url);
-    promise.catch(() => cache.delete(url));
-    cache.set(url, promise);
-  }
-  return promise;
-}
-
-export function useDuration(url: string | null): number | null {
-  const [duration, setDuration] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (!url) return;
-    let cancelled = false;
-    getDuration(url).then(
-      (seconds) => {
-        if (!cancelled) setDuration(seconds);
-      },
-      () => {}
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [url]);
-
-  return duration;
-}
-
-/** Total duration in seconds across urls, or null while any is unresolved. */
-export function useTotalDuration(urls: Array<string | null>): number | null {
-  const [total, setTotal] = useState<number | null>(null);
-
-  const key = urls.filter(Boolean).join("|");
-
-  useEffect(() => {
-    const playable = key === "" ? [] : key.split("|");
-    if (playable.length === 0) return;
-    let cancelled = false;
-    Promise.all(playable.map((url) => getDuration(url))).then(
-      (durations) => {
-        if (!cancelled) setTotal(durations.reduce((sum, d) => sum + d, 0));
-      },
-      () => {}
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [key]);
-
-  return total;
-}
 
 export function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);

--- a/supabase/migrations/20260712001200_version_duration.sql
+++ b/supabase/migrations/20260712001200_version_duration.sql
@@ -1,0 +1,37 @@
+-- Store each version's audio length so the client no longer has to sniff it by
+-- loading every track's audio file in the browser (which flooded the album/home
+-- pages with media requests: infinite spinners, device heat, stolen audio
+-- sessions, and WebContent OOM crashes on iOS).
+--
+-- duration_seconds is written on upload by set_version_file (the finalize RPC,
+-- called after the file lands in Storage) and backfilled for existing rows by
+-- scripts/backfill-version-durations.mjs.
+
+alter table public.versions
+  add column if not exists duration_seconds real;
+
+-- set_version_file gains an optional _duration. Drop the 2-arg signature first
+-- so PostgREST doesn't see two overloads (calls without _duration would become
+-- ambiguous). The default keeps it callable with just id + url, and coalesce
+-- preserves an existing duration when a caller omits it.
+drop function if exists public.set_version_file(uuid, text);
+
+create or replace function public.set_version_file(
+  _version_id   uuid,
+  _resource_url text,
+  _duration     real default null
+) returns void
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_version(_version_id) then
+    raise exception 'not a member of this version''s artist' using errcode = '42501';
+  end if;
+  update public.versions
+    set resource_url     = _resource_url,
+        duration_seconds = coalesce(_duration, duration_seconds)
+    where id = _version_id;
+end $$;
+
+revoke all on function public.set_version_file(uuid, text, real) from public;
+grant execute on function public.set_version_file(uuid, text, real) to authenticated;


### PR DESCRIPTION
## Summary

This PR eliminates client-side audio metadata sniffing that was causing performance and stability issues (infinite loading spinners, device heat, hijacked audio sessions, and iOS WebContent OOM crashes). Audio durations are now computed once on upload and stored in the database, then served to clients.

## Key Changes

- **Database schema**: Added `duration_seconds` column to `versions` table via migration
- **Upload flow**: Modified `set_version_file` RPC to accept and store duration; `uploadVersionAudio` now measures duration from the local file before upload using `audioDurationFromFile`
- **Data layer**: New `attachDurations` function in `data.ts` batches duration lookups from `versions` table and populates the `Track.duration` field; applied to all track-fetching queries
- **Client-side removal**: Deleted `useDuration` and `useTotalDuration` hooks and the entire duration-loading queue system from `durations.ts`; kept only `formatTime` utility
- **Component updates**: `AlbumInfos` and `AlbumTrack` now use server-provided `Track.duration` instead of client-side resolution
- **Backfill script**: Added `scripts/backfill-version-durations.mjs` to compute and store durations for pre-existing versions by parsing MP4 `mvhd` atoms from uploaded files (no external dependencies)

## Implementation Details

- Duration is measured once from the user's local file during upload (no network cost), avoiding repeated client-side decoding
- The backfill script parses MP4 box structure directly to extract timescale and duration from the `moov` › `mvhd` atom, handling both 32-bit and 64-bit time values
- `attachDurations` uses a single batched query per page load, keyed on version IDs already present in track data
- Duration failures are graceful: null values in the UI simply omit the time display rather than breaking the page
- The RPC uses `coalesce` to preserve existing durations when callers omit the parameter, maintaining backward compatibility

https://claude.ai/code/session_014N8xz8xvj4wr3egWoBgFhH