### PR TITLE
Refactor AlbumSwitcher to exclude active album and improve animations

### DIFF
--- a/src/components/AlbumCover.module.css
+++ b/src/components/AlbumCover.module.css
@@ -3,6 +3,7 @@
   --vinyl: 0.94; /* vinyl diameter */
   --peek: 0.16; /* resting: vinyl overhang beyond the cover's right edge */
   --slide: 0.46; /* active: extra rightward slide (~66% of the disc exposed) */
+  --roll: 2.5deg; /* active: vinyl spin, as if rolling out of the sleeve */
   --tilt: -2deg; /* active: cover rotation */
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 
@@ -68,7 +69,8 @@
   width: calc(var(--size) * var(--vinyl));
   aspect-ratio: 1;
   transform: translateY(-50%)
-    translateX(calc(var(--extract, 0) * var(--size) * var(--slide)));
+    translateX(calc(var(--extract, 0) * var(--size) * var(--slide)))
+    rotate(calc(var(--extract, 0) * var(--roll)));
   transition: transform 0.55s var(--ease);
   z-index: 0;
 }

--- a/src/components/AlbumSwitcher.module.css
+++ b/src/components/AlbumSwitcher.module.css
@@ -12,9 +12,10 @@
 }
 
 /* All albums read at full opacity at rest; hovering one fades the rest so the
-   focus sits on the item being pointed at. */
-.switcher:hover .item,
-.switcher:focus-within .item {
+   focus sits on the item being pointed at. The :not() keeps the hovered/focused
+   item itself clear and avoids it losing a specificity race to this rule. */
+.switcher:hover .item:not(:hover),
+.switcher:focus-within .item:not(:focus-visible) {
   opacity: 0.4;
 }
 

--- a/src/components/AlbumSwitcher.module.css
+++ b/src/components/AlbumSwitcher.module.css
@@ -8,20 +8,21 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  opacity: 0.33;
   transition: opacity 0.15s ease;
+}
+
+/* All albums read at full opacity at rest; hovering one fades the rest so the
+   focus sits on the item being pointed at. */
+.switcher:hover .item,
+.switcher:focus-within .item {
+  opacity: 0.4;
 }
 
 .item:hover,
 .item:focus-visible {
-  opacity: 0.66;
+  opacity: 1;
   /* Slide the vinyl out of the hovered nav item's cover. */
   --extract: 1;
-}
-
-.active,
-.active:hover {
-  opacity: 1;
 }
 
 .text {
@@ -29,6 +30,11 @@
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  /* Rather than the vinyl pushing into the name, the name/meta slide out of its
+     way in step with the disc. Distance mirrors the cover geometry: --size (67)
+     * --slide (0.46) ≈ 31px. */
+  transform: translateX(calc(var(--extract, 0) * 31px));
+  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .name {

--- a/src/components/AlbumSwitcher.tsx
+++ b/src/components/AlbumSwitcher.tsx
@@ -12,37 +12,31 @@ type Props = {
 
 /** Album page navigation — vertical rail on desktop, horizontal strip on mobile. */
 export default function AlbumSwitcher({ albums, activeId }: Props) {
-  const sorted = [
-    ...albums.filter((album) => album.id === activeId),
-    ...albums.filter((album) => album.id !== activeId),
-  ];
+  // The active album already headlines the main card, so skip it here to avoid
+  // showing its cover twice.
+  const others = albums.filter((album) => album.id !== activeId);
 
   return (
     <nav className={styles.switcher} aria-label="Albums">
-      {sorted.map((album) => {
-        const active = album.id === activeId;
-        return (
-          <Link
-            key={album.id}
-            href={`/albums/${album.id}`}
-            className={`${styles.item} ${active ? styles.active : ""}`}
-            aria-current={active ? "page" : undefined}
-            style={paletteVars(getPalette(album))}
-          >
-            <AlbumCoverLive
-              albumId={album.id}
-              coverUrl={album.cover_url}
-              alt=""
-              size={67}
-              reserve
-            />
-            <span className={styles.text}>
-              <span className={styles.name}>{album.name}</span>
-              <AlbumInfos tracks={album.tracks} />
-            </span>
-          </Link>
-        );
-      })}
+      {others.map((album) => (
+        <Link
+          key={album.id}
+          href={`/albums/${album.id}`}
+          className={styles.item}
+          style={paletteVars(getPalette(album))}
+        >
+          <AlbumCoverLive
+            albumId={album.id}
+            coverUrl={album.cover_url}
+            alt=""
+            size={67}
+          />
+          <span className={styles.text}>
+            <span className={styles.name}>{album.name}</span>
+            <AlbumInfos tracks={album.tracks} />
+          </span>
+        </Link>
+      ))}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
This PR refactors the AlbumSwitcher component to exclude the currently active album from the navigation rail/strip, since it's already displayed in the main card. The changes also enhance the visual feedback with improved hover states and smoother animations.

## Key Changes
- **Simplified album filtering**: Removed the logic that placed the active album first in the list. Now only displays non-active albums, eliminating duplicate cover display.
- **Updated hover behavior**: Changed from a static low opacity (0.33) to a dynamic system where all items start at full opacity, and non-hovered items fade to 0.4 opacity when hovering or focusing within the switcher.
- **Removed active state styling**: Eliminated the `.active` class and its associated styles since the active album is no longer rendered in the switcher.
- **Enhanced vinyl animation**: Added a rotation transform (`--roll: 2.5deg`) to the vinyl disc that spins as it slides out, creating a more realistic "rolling out of the sleeve" effect.
- **Added text slide animation**: The album name and metadata now slide out of the way as the vinyl disc extracts, with a dedicated transform and easing curve that mirrors the cover geometry.
- **Improved code clarity**: Converted the JSX from a verbose ternary expression to a cleaner arrow function, and added explanatory comments for the animation behavior.

## Implementation Details
- The vinyl rotation and text translation both use the same `--extract` CSS variable and matching transition timing (0.55s with cubic-bezier easing) for coordinated animation.
- The text translation distance (31px) is calculated to match the cover geometry: `--size (67) * --slide (0.46) ≈ 31px`.
- Hover/focus-within states now create a "spotlight" effect where the focused item stands out at full opacity while others dim to 0.4.

https://claude.ai/code/session_01BB8tLuG5b5wZtx5D9hj5nt