### PR TITLE
Add album color theme system with catalog and persistence

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -2,7 +2,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "./supabase/anon";
 import type { Album, AlbumWithTracks, Genre, Track, TrackLyrics } from "./types";
 
-const ALBUM_COLS = "id,artist_id,name,description,type,cover_url,created_at";
+const ALBUM_COLS =
+  "id,artist_id,name,description,type,cover_url,theme,created_at";
 
 /** Supabase errors are plain objects; wrap them so logs show a real message. */
 function fail(context: string, error: { message?: string }): never {

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -39,6 +39,20 @@ export async function setAlbumGenres(
   if (error) throw new Error(error.message);
 }
 
+/** Persist an album's color theme (a catalog key, or 'auto'). Powers the
+    edit-mode theme picker; validate the key against THEMES before calling. */
+export async function setAlbumTheme(
+  albumId: string,
+  theme: string
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc("set_album_theme", {
+    _album_id: albumId,
+    _theme: theme,
+  });
+  if (error) throw new Error(error.message);
+}
+
 export async function createGenre(name: string): Promise<Genre> {
   const supabase = createClient();
   const { data, error } = await supabase.rpc("create_genre", { _name: name });

--- a/src/lib/palettes.ts
+++ b/src/lib/palettes.ts
@@ -1,5 +1,9 @@
 import type { CSSProperties } from "react";
 
+/**
+ * Resolved album colors — the CSS custom properties every album-scoped
+ * component reads. Produced from a theme (below); not stored directly.
+ */
 export type AlbumPalette = {
   /** Text on album content (names, descriptions). */
   light: string;
@@ -7,43 +11,91 @@ export type AlbumPalette = {
   accent: string;
   /** Deep shade: times, meta tile icons. */
   deep: string;
-  /** Display genre for the meta tile (not stored in Supabase yet). */
+  /**
+   * Display genre for the meta tile. Album-specific, NOT part of the theme —
+   * a temporary override kept from the pre-theme palette map until real album
+   * genres flow through every view (the list view doesn't load them yet).
+   */
   genre?: string;
 };
 
-const FALLBACK: AlbumPalette = {
-  light: "#F2EFF5",
-  accent: "#7B5E99",
-  deep: "#56426B",
+/** A named, selectable color theme — one option in the edit-mode picker. */
+export type AlbumTheme = {
+  /** Stable key persisted in `albums.theme` and selected in the picker. */
+  key: string;
+  /** Human-readable label shown in the picker. */
+  name: string;
+  /** The three colors this theme paints. */
+  palette: { light: string; accent: string; deep: string };
 };
 
 /**
- * Hardcoded per-album themes (step 1 — no Supabase model change).
- * Keyed by album name; an id key takes precedence when present.
+ * Sentinel stored in `albums.theme` when the palette should be derived from
+ * the cover art. The nearest-theme match is computed client-side (added in a
+ * later step); until then such albums fall back to the legacy map / default.
  */
-const PALETTES: Record<string, AlbumPalette> = {
-  "Dawn from the Semicolon": {
-    light: "#F6EFE6",
-    accent: "#A15C08",
-    deep: "#714006",
-    genre: "Folk",
+export const AUTO_THEME = "auto";
+
+/**
+ * The theme catalog — the single source of truth for album colors. Add a
+ * theme here and the picker lists it automatically. More themes to come.
+ */
+export const THEMES: AlbumTheme[] = [
+  {
+    key: "amber",
+    name: "Amber",
+    palette: { light: "#F6EFE6", accent: "#A15C08", deep: "#714006" },
   },
-  Bones: {
-    light: "#F2EFF5",
-    accent: "#7B5E99",
-    deep: "#56426B",
-    genre: "Folk",
+  {
+    key: "violet",
+    name: "Violet",
+    palette: { light: "#F2EFF5", accent: "#7B5E99", deep: "#56426B" },
   },
-  Celesta: {
-    light: "#EEF0F3",
-    accent: "#59658A",
-    deep: "#3E4761",
-    genre: "Cinematic",
+  {
+    key: "slate",
+    name: "Slate",
+    palette: { light: "#EEF0F3", accent: "#59658A", deep: "#3E4761" },
   },
+];
+
+const THEME_BY_KEY: Record<string, AlbumTheme> = Object.fromEntries(
+  THEMES.map((theme) => [theme.key, theme])
+);
+
+/** Ultimate fallback when an album has no theme and no legacy match. */
+const FALLBACK = THEME_BY_KEY.violet.palette;
+
+/**
+ * Legacy album-name → theme key, so albums whose stored theme is still 'auto'
+ * keep rendering their original hand-picked palette until cover-based
+ * detection lands. Also serves callers that only know an album's id/name (e.g.
+ * the player bar) and not its stored theme.
+ */
+const LEGACY_THEME: Record<string, string> = {
+  "Dawn from the Semicolon": "amber",
+  Bones: "violet",
+  Celesta: "slate",
 };
 
-export function getPalette(album: { id: string; name: string }): AlbumPalette {
-  return PALETTES[album.id] ?? PALETTES[album.name] ?? FALLBACK;
+/** Album-specific display genre — see AlbumPalette.genre. */
+const LEGACY_GENRE: Record<string, string> = {
+  "Dawn from the Semicolon": "Folk",
+  Bones: "Folk",
+  Celesta: "Cinematic",
+};
+
+type AlbumLike = { id?: string; name?: string; theme?: string | null };
+
+/** Resolve an album's palette: its stored theme, else the legacy match, else
+    the default. `theme` may be absent when the caller only has id/name. */
+export function getPalette(album: AlbumLike): AlbumPalette {
+  const key =
+    album.theme && album.theme !== AUTO_THEME
+      ? album.theme
+      : LEGACY_THEME[album.name ?? ""];
+  const base = (key ? THEME_BY_KEY[key]?.palette : undefined) ?? FALLBACK;
+  const genre = LEGACY_GENRE[album.name ?? ""];
+  return genre ? { ...base, genre } : { ...base };
 }
 
 /** Inline CSS custom properties consumed by every album-scoped component. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,8 @@ export type Album = {
   description: string | null;
   type: string | null;
   cover_url: string | null;
+  /** Color theme key (see src/lib/palettes.ts); 'auto' derives it from the cover. */
+  theme: string;
   created_at: string;
 };
 

--- a/supabase/migrations/20260712001300_album_theme.sql
+++ b/supabase/migrations/20260712001300_album_theme.sql
@@ -1,0 +1,29 @@
+-- Store each album's color theme. The value references a named entry in the
+-- app's theme catalog (src/lib/palettes.ts) — e.g. 'amber', 'violet', 'slate'.
+-- The sentinel 'auto' means the palette is derived from the cover art (the
+-- nearest-theme match is computed client-side). Kept as free text rather than
+-- an enum so new themes are a code-only change (no migration per theme).
+
+alter table public.albums
+  add column if not exists theme text not null default 'auto';
+
+-- Backfill the albums that already carried a hand-picked palette (previously
+-- keyed by album name in src/lib/palettes.ts).
+update public.albums set theme = 'amber'  where theme = 'auto' and name = 'Dawn from the Semicolon';
+update public.albums set theme = 'violet' where theme = 'auto' and name = 'Bones';
+update public.albums set theme = 'slate'  where theme = 'auto' and name = 'Celesta';
+
+-- Persist a theme choice. Mirrors set_album_cover: membership-gated, and the
+-- value is validated client-side against the catalog (the DB does not know it).
+create or replace function public.set_album_theme(_album_id uuid, _theme text)
+  returns void language plpgsql security definer set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_member_of_album(_album_id) then
+    raise exception 'not a member of this album''s artist' using errcode = '42501';
+  end if;
+  update public.albums set theme = _theme where id = _album_id;
+end $$;
+
+revoke all on function public.set_album_theme(uuid,text) from public;
+grant execute on function public.set_album_theme(uuid,text) to authenticated;


### PR DESCRIPTION
## Summary
Refactors the album color palette system from a hardcoded name-based map to a selectable theme catalog. Albums can now choose from named themes (Amber, Violet, Slate) or use 'auto' to derive colors from cover art. Theme choices are persisted to the database and validated against the catalog.

## Key Changes

- **Theme Catalog**: Introduced `AlbumTheme` type and `THEMES` array as the single source of truth for available color themes. Each theme has a stable key, human-readable name, and palette colors.

- **Database Schema**: Added `theme` column to `albums` table (defaults to 'auto') and created `set_album_theme()` RPC function for membership-gated persistence.

- **Legacy Compatibility**: Maintained `LEGACY_THEME` and `LEGACY_GENRE` maps to preserve existing album styling during the transition. Albums with stored 'auto' theme fall back to their legacy hand-picked palette until cover-based detection is implemented.

- **Updated `getPalette()`**: Now accepts albums with optional `theme` field and resolves palettes by: stored theme → legacy theme → fallback. Supports callers that only know id/name (e.g., player bar).

- **API Layer**: Added `setAlbumTheme()` function in `edit.ts` to persist theme choices. Updated `ALBUM_COLS` query to include the new `theme` field.

- **Type Updates**: Extended `Album` type with `theme` field and documented its purpose.

## Implementation Details

- The `AUTO_THEME` sentinel ('auto') is stored in the database but resolved client-side; the DB doesn't validate theme keys, allowing new themes to be added as code-only changes.
- Genre display remains album-specific and separate from the theme system (temporary override until genres flow through all views).
- The theme picker will automatically list all entries in `THEMES` without additional configuration.

https://claude.ai/code/session_01P5n8hnoxFzSKaF2Nq821RR