### PR TITLE
Hide versionless tracks from listeners

### DIFF
--- a/src/components/AlbumDetailCard.module.css
+++ b/src/components/AlbumDetailCard.module.css
@@ -24,6 +24,14 @@
   line-height: 22px;
 }
 
+.unavailable {
+  color: var(--album-light);
+  font-size: 16px;
+  line-height: 22px;
+  text-align: center;
+  padding: 32px 0;
+}
+
 .editBar {
   display: flex;
   justify-content: flex-end;

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import type { AlbumWithTracks, TrackLyrics } from "@/lib/types";
+import { useMemo, useState } from "react";
+import { hasVersion, type AlbumWithTracks, type TrackLyrics } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
 import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumHeader from "./AlbumHeader";
@@ -25,12 +25,31 @@ type Props = {
 
 /** Album page main card (Figma "AlbumCard" on Album frames). */
 export default function AlbumDetailCard({ album, lyrics }: Props) {
-  const { editing, draft, setField } = useAlbumEdit();
+  const { editing, canEdit, draft, setField } = useAlbumEdit();
   const palette = getPalette(album);
   // Track drawer target: null = closed, { trackId: null } = create mode.
   // Mounted at card level (not inside the setlist) so a setlist resync or a
   // staged row removal can't unmount it mid-upload.
   const [drawer, setDrawer] = useState<{ trackId: string | null } | null>(null);
+
+  // Read mode shows the listener view (versioned tracks only); a signed-in
+  // owner sees the full list, matching what they'd manage in edit mode.
+  const versioned = useMemo(() => album.tracks.filter(hasVersion), [album.tracks]);
+  const readTracks = canEdit ? album.tracks : versioned;
+  const readAlbum = useMemo(
+    () => ({ ...album, tracks: readTracks }),
+    [album, readTracks]
+  );
+
+  // An album composed only of versionless tracks is hidden from listeners even
+  // on a direct link (it never appears in any listing). Owners still reach it.
+  if (versioned.length === 0 && !canEdit) {
+    return (
+      <article className={styles.card} style={paletteVars(palette)}>
+        <p className={styles.unavailable}>This album isn’t available yet.</p>
+      </article>
+    );
+  }
 
   return (
     <article className={styles.card} style={paletteVars(palette)}>
@@ -67,7 +86,7 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
               <AlbumInfos tracks={album.tracks} />
             </div>
           ) : (
-            <AlbumHeader album={album} />
+            <AlbumHeader album={readAlbum} />
           )}
 
           {editing ? (
@@ -111,7 +130,7 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
           onAddTrack={() => setDrawer({ trackId: null })}
         />
       ) : (
-        <AlbumPlaylist tracks={album.tracks} variant="detailed" lyrics={lyrics} />
+        <AlbumPlaylist tracks={readTracks} variant="detailed" lyrics={lyrics} />
       )}
       {drawer && (
         <TrackDrawer

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,6 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "./supabase/anon";
-import type { Album, AlbumWithTracks, Genre, Track, TrackLyrics } from "./types";
+import {
+  hasVersion,
+  type Album,
+  type AlbumWithTracks,
+  type Genre,
+  type Track,
+  type TrackLyrics,
+} from "./types";
 
 const ALBUM_COLS =
   "id,artist_id,name,description,type,cover_url,theme,created_at";
@@ -84,9 +91,13 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
   if (albumsRes.error) fail("Failed to load albums", albumsRes.error);
   if (tracksRes.error) fail("Failed to load tracks", tracksRes.error);
 
-  const tracks = (tracksRes.data ?? []) as Track[];
+  // Listener view: drop versionless tracks, then albums left with none. Owners
+  // reach an album's full track list through getAlbumWithTracks (edit mode).
+  const tracks = ((tracksRes.data ?? []) as Track[]).filter(hasVersion);
   await attachDurations(supabase, tracks);
-  return groupTracks((albumsRes.data ?? []) as Album[], tracks);
+  return groupTracks((albumsRes.data ?? []) as Album[], tracks).filter(
+    (album) => album.tracks.length > 0
+  );
 }
 
 export async function getAlbumWithTracks(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,4 +56,14 @@ export type AlbumWithTracks = Album & {
   genres: Genre[];
 };
 
+/**
+ * A track is publicly visible once it carries at least one version. Versionless
+ * tracks — and albums composed only of them — are hidden from listeners; owners
+ * still see them (in read mode when signed in, and always in edit mode) so they
+ * can attach a first version.
+ */
+export function hasVersion(track: Track): boolean {
+  return track.latest_version_id !== null;
+}
+
 export type TrackLyrics = Record<string, string | null>;


### PR DESCRIPTION
## Summary
Implements visibility filtering for tracks and albums based on version status. Tracks without versions are now hidden from listeners while remaining visible to authenticated owners, allowing them to manage incomplete content.

## Key Changes
- **Added `hasVersion()` utility function** in `types.ts` to identify publicly visible tracks (those with `latest_version_id !== null`)
- **Updated `getAlbumsWithTracks()`** to filter out versionless tracks from the listener view and remove albums that have no visible tracks after filtering
- **Modified `AlbumDetailCard`** to:
  - Use `canEdit` from `useAlbumEdit()` to determine user permissions
  - Calculate `versioned` tracks and conditionally show either full or filtered track list based on edit permissions
  - Display an "unavailable" message when an album has no versioned tracks and the user is not an owner
  - Pass filtered track data to child components (`AlbumHeader`, `AlbumPlaylist`)
- **Added `.unavailable` CSS class** for styling the unavailable album message

## Implementation Details
- Owners (authenticated users with edit permissions) see the complete track list in both read and edit modes
- Listeners see only tracks with versions; albums composed entirely of versionless tracks are hidden even on direct links
- The filtering is applied at multiple levels: data fetching (`getAlbumsWithTracks`), component rendering (`AlbumDetailCard`), and display (`AlbumHeader`, `AlbumPlaylist`)
- Edit mode continues to show all tracks regardless of version status, enabling owners to add versions to incomplete tracks

https://claude.ai/code/session_01PqVBkhPn1quQXRqgcAadH4