### PR TITLE
Add play recording analytics with RPC and client-side cooldown

### DIFF
--- a/src/lib/plays.ts
+++ b/src/lib/plays.ts
@@ -1,0 +1,61 @@
+/**
+ * Listening analytics for Melogram.
+ *
+ * Records one row per play into `public.track_plays` via the `record_play` RPC.
+ * Ported from the old SvelteKit `analytics.ts`, minus the consent gate: plays
+ * are logged anonymously using a random UUID kept in localStorage under
+ * `melogram_anonymous_id` (no cookies, no IP, no PII). The same key as the old
+ * app, so returning visitors keep their anonymous identity. For signed-in users
+ * the RPC attributes the play to their account and ignores the anonymous id.
+ */
+import { createClient } from "@/lib/supabase/client";
+
+/** localStorage key holding the anonymous tracking UUID (shared with the old app). */
+const ANONYMOUS_ID_KEY = "melogram_anonymous_id";
+
+/** Minimum milliseconds between two logged plays of the same track+source. */
+const PLAY_COOLDOWN_MS = 10_000;
+
+const recentPlays = new Map<string, number>();
+
+function getOrCreateAnonymousId(): string | null {
+  if (typeof window === "undefined") return null;
+  let id = localStorage.getItem(ANONYMOUS_ID_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(ANONYMOUS_ID_KEY, id);
+  }
+  return id;
+}
+
+/**
+ * Log a track play. A client-side cooldown suppresses duplicate events for the
+ * same track+source within {@link PLAY_COOLDOWN_MS} (the RPC rate-limits too, as
+ * a backstop). Errors are swallowed — analytics must never break playback.
+ */
+export async function recordPlay(trackId: string, source: string): Promise<void> {
+  if (!trackId || typeof window === "undefined") return;
+
+  const key = `${trackId}:${source}`;
+  const now = Date.now();
+
+  // Prune stale entries to keep the map from growing unbounded.
+  for (const [k, ts] of recentPlays) {
+    if (now - ts >= PLAY_COOLDOWN_MS) recentPlays.delete(k);
+  }
+
+  const last = recentPlays.get(key);
+  if (last !== undefined && now - last < PLAY_COOLDOWN_MS) return;
+  recentPlays.set(key, now);
+
+  const anonymousId = getOrCreateAnonymousId();
+  try {
+    await createClient().rpc("record_play", {
+      _track_id: trackId,
+      _anonymous_id: anonymousId,
+      _source: source,
+    });
+  } catch {
+    // Silently ignore — analytics must never break the app.
+  }
+}

--- a/src/player/PlayerProvider.tsx
+++ b/src/player/PlayerProvider.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
 } from "react";
 import type { Track } from "@/lib/types";
+import { recordPlay } from "@/lib/plays";
 
 export type PlayerTrack = {
   id: string;
@@ -176,7 +177,10 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       setDuration(0);
       setTime(0);
       audio.src = track.url;
-      if (autoplay) void audio.play();
+      if (autoplay) {
+        void audio.play();
+        void recordPlay(track.id, "web");
+      }
       syncMetadata(track);
       syncPositionState(true);
     },

--- a/supabase/migrations/20260713000000_rpc_record_play.sql
+++ b/supabase/migrations/20260713000000_rpc_record_play.sql
@@ -1,0 +1,60 @@
+-- Records a listening event into public.track_plays.
+--
+-- The rewrite to Next.js dropped the old play-recording code (an API route that
+-- inserted via the service role); playback is anonymous and the app has no
+-- service-role key. This SECURITY DEFINER RPC lets both anonymous and
+-- authenticated clients record a play without loosening the table's RLS — the
+-- same pattern the content-editing RPCs use. is_artist_member is likewise
+-- granted to anon (see 20260712000100_artist_members.sql).
+--
+-- For authenticated callers the play is attributed to auth.uid() and the passed
+-- _anonymous_id is ignored; otherwise it is attributed to _anonymous_id (a
+-- random UUID kept in the browser's localStorage). This satisfies the table's
+-- XOR track_plays_identity_check. A 10-second per-identity rate limit mirrors
+-- the cooldown the old /api/track-plays route enforced.
+create or replace function public.record_play(
+  _track_id     uuid,
+  _anonymous_id uuid default null,
+  _source       text default null
+) returns void
+  language plpgsql security definer set search_path = public, pg_temp
+as $$
+declare _uid uuid := auth.uid();
+begin
+  -- Ignore plays for tracks that don't exist (also satisfies the FK).
+  if not exists (select 1 from public.tracks where id = _track_id) then
+    return;
+  end if;
+
+  if _uid is not null then
+    -- Authenticated play. Skip if this user already logged this track recently.
+    if exists (
+      select 1 from public.track_plays
+      where track_id = _track_id
+        and user_id = _uid
+        and created_at > now() - interval '10 seconds'
+    ) then
+      return;
+    end if;
+    insert into public.track_plays (track_id, user_id, source)
+      values (_track_id, _uid, _source);
+  else
+    -- Anonymous play. Requires an anonymous id to attribute the row.
+    if _anonymous_id is null then
+      return;
+    end if;
+    if exists (
+      select 1 from public.track_plays
+      where track_id = _track_id
+        and anonymous_id = _anonymous_id
+        and created_at > now() - interval '10 seconds'
+    ) then
+      return;
+    end if;
+    insert into public.track_plays (track_id, anonymous_id, source)
+      values (_track_id, _anonymous_id, _source);
+  end if;
+end $$;
+
+revoke all on function public.record_play(uuid, uuid, text) from public;
+grant execute on function public.record_play(uuid, uuid, text) to anon, authenticated;


### PR DESCRIPTION
## Summary
Implements listening analytics for Melogram by adding a new `record_play` RPC function and client-side play recording logic. Plays are logged anonymously using a random UUID stored in localStorage, with the same key as the legacy app to preserve user identity across versions. Authenticated users' plays are attributed to their account.

## Key Changes
- **New RPC function** (`record_play`): A SECURITY DEFINER function that records track plays to `public.track_plays` with built-in rate limiting (10-second cooldown per identity). Handles both authenticated users (attributed to `auth.uid()`) and anonymous users (attributed to a random UUID).
- **Client-side play recording** (`src/lib/plays.ts`): Exports `recordPlay()` function that manages anonymous ID generation/persistence and enforces a 10-second client-side cooldown per track+source combination to prevent duplicate submissions.
- **Player integration**: Calls `recordPlay()` when a track starts playing in the PlayerProvider.

## Implementation Details
- Anonymous IDs are stored in localStorage under `melogram_anonymous_id` (shared key with the old app for continuity)
- No cookies, IP logging, or PII collected; plays are logged anonymously by default
- Dual rate limiting: client-side cooldown (10s) + RPC-level check (10s) as a backstop
- Errors in analytics are silently swallowed to ensure playback is never interrupted
- The RPC uses XOR identity check (either `user_id` or `anonymous_id`, never both) to satisfy table constraints
- RPC is granted to both `anon` and `authenticated` roles for universal access

https://claude.ai/code/session_01SaUjozVnV1tgpdbKNPYQmA