### PR TITLE
Fix vinyl disc compositing layer issue on Android Chrome

### DIFF
--- a/src/components/VinylDisc.module.css
+++ b/src/components/VinylDisc.module.css
@@ -9,6 +9,15 @@
      composites against the colour + cover — never the page behind it. */
   isolation: isolate;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  /* Pin the disc to its own permanent compositing layer so the luminosity blend
+     always rasterizes against its own colour + cover backdrop. Without it, an
+     ancestor's one-shot transform *transition* (the cover's slide-out) briefly
+     promotes then demotes the disc, and Android Chrome mis-composites the nested
+     mix-blend-mode during that churn — the grooves lose their colour for a frame
+     or two, intermittently. The player's disc never shows this because its
+     infinite spin keeps the layer permanently promoted; this makes every disc
+     behave the same, stable way. */
+  transform: translateZ(0);
 }
 
 /* 1. Solid fill in the album's primary theme colour. */


### PR DESCRIPTION
## Summary
Fixed a rendering issue where the vinyl disc's luminosity blend mode was incorrectly composited during cover slide-out animations on Android Chrome, causing the disc grooves to briefly lose their color.

## Changes
- Added `transform: translateZ(0)` to the `.VinylDisc` component to pin it to its own permanent compositing layer

## Implementation Details
The issue occurred because ancestor transform transitions (the cover's slide-out animation) would temporarily promote and demote the disc's compositing layer. During this churn, Android Chrome would mis-composite the nested `mix-blend-mode`, causing visual artifacts where the grooves would lose their color for a frame or two.

By applying `transform: translateZ(0)`, the disc is now pinned to a permanent compositing layer, ensuring the luminosity blend mode always rasterizes against its own color and cover backdrop consistently. This makes the disc's rendering behavior stable and matches the behavior of the player's spinning disc, which was already unaffected due to its infinite animation keeping the layer permanently promoted.

https://claude.ai/code/session_01LZsDHGt7cB6hc6ho9vVACj