### PR TITLE
Fix homepage track order, lyrics button, like count, mobile header

### DIFF
--- a/src/components/AlbumTrack.tsx
+++ b/src/components/AlbumTrack.tsx
@@ -69,12 +69,11 @@ export default function AlbumTrack({
           {duration !== null ? formatTime(duration) : "–:–"}
         </span>
         <LikeButton trackId={track.track_id} likeCount={track.like_count ?? 0} />
-        {detailed && (
+        {detailed && lyrics && (
           <button
             type="button"
             className={styles.iconButton}
             aria-label={`Lyrics of ${track.track_name}`}
-            disabled={!lyrics}
             onClick={() => setLyricsOpen(true)}
           >
             <Mic size={20} strokeWidth={2} />

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -236,4 +236,15 @@
   .compact .body {
     padding: 24px 16px;
   }
+
+  /* Stack the social row below the logo + name instead of squeezing it
+     alongside them: let the header wrap and give social a full-width line. */
+  .compact {
+    flex-wrap: wrap;
+  }
+
+  .compact .social {
+    flex-basis: 100%;
+    padding: 0 16px 16px;
+  }
 }

--- a/src/components/LikeButton.module.css
+++ b/src/components/LikeButton.module.css
@@ -1,4 +1,5 @@
 .like {
+  position: relative;
   height: 40px;
   padding: 0 10px;
   border-radius: var(--radius-button);
@@ -27,9 +28,43 @@
   color: var(--album-accent);
 }
 
-.count {
-  font-size: 14px;
+/* Branded tooltip: the like count only surfaces on hover/focus, floating
+   above the heart in the album palette's deep tone. */
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  padding: 4px 10px;
+  border-radius: var(--radius-button);
+  background: var(--album-deep);
+  color: var(--album-light);
+  font-size: 13px;
   font-weight: 500;
   line-height: 18px;
-  min-width: 8px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease-out, transform 0.15s ease-out,
+    visibility 0.15s ease-out;
+  z-index: 2;
+}
+
+/* little pointer at the bottom of the bubble */
+.tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--album-deep);
+}
+
+.like:hover .tooltip,
+.like:focus-visible .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
 }

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -45,10 +45,20 @@ export default function LikeButton({ trackId, likeCount }: Props) {
       onClick={onClick}
       disabled={busy}
       aria-pressed={liked}
-      aria-label={liked ? "Unlike" : "Like"}
+      aria-label={
+        count > 0
+          ? `${liked ? "Unlike" : "Like"} — ${count} ${count === 1 ? "like" : "likes"}`
+          : liked
+            ? "Unlike"
+            : "Like"
+      }
     >
       <Heart size={20} strokeWidth={2} fill={liked ? "currentColor" : "none"} />
-      {count > 0 && <span className={styles.count}>{count}</span>}
+      {count > 0 && (
+        <span className={styles.tooltip} role="tooltip">
+          {count} {count === 1 ? "like" : "likes"}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -104,13 +104,26 @@ async function attachAlbumThemes(
   }
 }
 
-function groupTracks(albums: Album[], tracks: Track[]): AlbumWithTracks[] {
+function groupTracks(
+  albums: Album[],
+  tracks: Track[],
+  position: Map<string, number>
+): AlbumWithTracks[] {
   const byAlbum = new Map<string, Track[]>();
   for (const track of tracks) {
     if (!track.album_id) continue;
     const list = byAlbum.get(track.album_id) ?? [];
     list.push(track);
     byAlbum.set(track.album_id, list);
+  }
+  // Respect the artist-set order from album_tracks.position; tracks without a
+  // recorded position fall to the end, keeping the query's release-date order.
+  for (const list of byAlbum.values()) {
+    list.sort(
+      (a, b) =>
+        (position.get(a.track_id) ?? Number.MAX_SAFE_INTEGER) -
+        (position.get(b.track_id) ?? Number.MAX_SAFE_INTEGER)
+    );
   }
   return albums.map((album) => ({
     ...album,
@@ -120,7 +133,7 @@ function groupTracks(albums: Album[], tracks: Track[]): AlbumWithTracks[] {
 }
 
 export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
-  const [albumsRes, tracksRes] = await Promise.all([
+  const [albumsRes, tracksRes, orderRes] = await Promise.all([
     supabase
       .from("albums")
       .select(ALBUM_COLS)
@@ -130,10 +143,19 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
       .select(TRACK_COLS)
       .not("album_id", "is", null)
       .order("latest_release_date", { ascending: false }),
+    supabase.from("album_tracks").select("track_id,position"),
   ]);
 
   if (albumsRes.error) fail("Failed to load albums", albumsRes.error);
   if (tracksRes.error) fail("Failed to load tracks", tracksRes.error);
+  if (orderRes.error) fail("Failed to load track order", orderRes.error);
+
+  const position = new Map(
+    (orderRes.data ?? []).map((r) => [
+      r.track_id as string,
+      r.position as number,
+    ])
+  );
 
   // Listener view: drop versionless tracks, then albums left with none. Owners
   // reach an album's full track list through getAlbumWithTracks (edit mode).
@@ -141,7 +163,9 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
   const tracks = ((tracksRes.data ?? []) as Track[]).filter(hasVersion);
   attachThemesFromAlbums(albums, tracks);
   await attachDurations(supabase, tracks);
-  return groupTracks(albums, tracks).filter((album) => album.tracks.length > 0);
+  return groupTracks(albums, tracks, position).filter(
+    (album) => album.tracks.length > 0
+  );
 }
 
 export async function getAlbumWithTracks(


### PR DESCRIPTION
- Homepage now sorts each album's tracks by the artist-set
  album_tracks.position instead of release date
- Lyrics button only renders on tracks that actually have lyrics
- Like count moves into a branded hover/focus tooltip instead of
  showing inline
- Compact header stacks the social icons below the logo and name on
  mobile

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KAUVwXid86J1kr2Zsf1HnD