### PR TITLE
Add home page Tracks section with Popular/Latest tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Home and Album pages.
 
 ## Pages
 
-- `/` — artist header (brand, bio, social links) + every album as a card with
-  cover, meta tiles, description and playlist
+- `/` — artist header (brand, bio, social links) then two tabbed sections: a
+  **Tracks** section of standalone tracks (the cover doubles as the play/pause
+  control) under _Popular_ / _Latests_ tabs, and an **Albums** section of album
+  cards filtered by genre. Popularity ranks a track by `likes × 10 + plays ÷ 10`
+  (play totals come from the `track_play_counts` view)
 - `/albums/[id]` — compact header, album switcher (rail on desktop,
   horizontal strip on mobile) and album detail with track descriptions and a
   lyrics sheet

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -7,27 +7,9 @@
   gap: 32px;
 }
 
-.albums {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 32px;
-  align-items: start;
-}
-
-@media (max-width: 1023px) {
-  .albums {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 767px) {
   .page {
     padding: 0 0 48px;
     gap: 24px;
-  }
-
-  .albums {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 48px;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,22 @@
 import Header from "@/components/Header";
-import AlbumCard from "@/components/AlbumCard";
-import { getAlbumsWithTracks } from "@/lib/data";
+import TracksSection from "@/components/TracksSection";
+import AlbumsSection from "@/components/AlbumsSection";
+import { getAlbumsWithTracks, getFeaturedTracks } from "@/lib/data";
 import styles from "./page.module.css";
 
 export const revalidate = 300;
 
 export default async function Home() {
   const albums = await getAlbumsWithTracks();
+  const { popular, latest } = await getFeaturedTracks(
+    albums.flatMap((album) => album.tracks)
+  );
 
   return (
     <div className={styles.page}>
       <Header variant="home" />
-      <main className={styles.albums}>
-        {albums.map((album) => (
-          <AlbumCard key={album.id} album={album} />
-        ))}
-      </main>
+      <TracksSection popular={popular} latest={latest} />
+      <AlbumsSection albums={albums} />
     </div>
   );
 }

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { AlbumWithTracks } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
+import { displayGenre } from "@/lib/genres";
 import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumHeader from "./AlbumHeader";
 import AlbumMetaTiles from "./AlbumMetaTiles";
@@ -27,7 +28,7 @@ export default function AlbumCard({ album }: { album: AlbumWithTracks }) {
       </Link>
       <AlbumHeader album={album} align="center" linked />
       <AlbumMetaTiles
-        genre={palette.genre ?? capitalize(album.type)}
+        genre={displayGenre(album)}
         year={new Date(album.created_at).getFullYear().toString()}
         direction="vertical"
       />
@@ -37,9 +38,4 @@ export default function AlbumCard({ album }: { album: AlbumWithTracks }) {
       <AlbumPlaylist tracks={album.tracks} variant="simple" />
     </article>
   );
-}
-
-function capitalize(value: string | null): string {
-  if (!value) return "Album";
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/src/components/AlbumDetailCard.tsx
+++ b/src/components/AlbumDetailCard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { hasVersion, type AlbumWithTracks, type TrackLyrics } from "@/lib/types";
 import { getPalette, paletteVars } from "@/lib/palettes";
+import { displayGenre } from "@/lib/genres";
 import AlbumCoverLive from "./AlbumCoverLive";
 import AlbumHeader from "./AlbumHeader";
 import AlbumInfos from "./AlbumInfos";
@@ -117,7 +118,7 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
             </>
           ) : (
             <AlbumMetaTiles
-              genre={palette.genre ?? capitalize(album.type)}
+              genre={displayGenre(album)}
               year={new Date(album.created_at).getFullYear().toString()}
               direction="horizontal"
             />
@@ -141,9 +142,4 @@ export default function AlbumDetailCard({ album, lyrics }: Props) {
       )}
     </article>
   );
-}
-
-function capitalize(value: string | null): string {
-  if (!value) return "Album";
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/src/components/AlbumsSection.module.css
+++ b/src/components/AlbumsSection.module.css
@@ -1,0 +1,34 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  align-items: start;
+}
+
+@media (max-width: 1023px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .section {
+    gap: 24px;
+  }
+
+  /* the header aligns with the page edge inset; the cards stay full-bleed */
+  .head {
+    padding: 0 24px;
+  }
+
+  .grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 48px;
+  }
+}

--- a/src/components/AlbumsSection.module.css
+++ b/src/components/AlbumsSection.module.css
@@ -19,12 +19,10 @@
 
 @media (max-width: 767px) {
   .section {
+    /* insets the header (its tabs still scroll edge to edge); the cards stay
+       full-bleed with their own internal padding */
+    --section-pad: 24px;
     gap: 24px;
-  }
-
-  /* the header aligns with the page edge inset; the cards stay full-bleed */
-  .head {
-    padding: 0 24px;
   }
 
   .grid {

--- a/src/components/AlbumsSection.tsx
+++ b/src/components/AlbumsSection.tsx
@@ -40,14 +40,12 @@ export default function AlbumsSection({ albums }: { albums: AlbumWithTracks[] })
 
   return (
     <section className={styles.section}>
-      <div className={styles.head}>
-        <SectionHeader
-          title={m.sections.albums}
-          tabs={tabs}
-          activeKey={active}
-          onSelect={setActive}
-        />
-      </div>
+      <SectionHeader
+        title={m.sections.albums}
+        tabs={tabs}
+        activeKey={active}
+        onSelect={setActive}
+      />
       <div className={styles.grid}>
         {visible.map((album) => (
           <AlbumCard key={album.id} album={album} />

--- a/src/components/AlbumsSection.tsx
+++ b/src/components/AlbumsSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { AlbumWithTracks } from "@/lib/types";
+import { albumFilterGenres } from "@/lib/genres";
+import { useMessages } from "@/lib/i18n/LocaleProvider";
+import SectionHeader, { type SectionTab } from "./SectionHeader";
+import AlbumCard from "./AlbumCard";
+import styles from "./AlbumsSection.module.css";
+
+const ALL = "__all__";
+
+/** Home "Albums" section: every album, filtered by genre tabs. */
+export default function AlbumsSection({ albums }: { albums: AlbumWithTracks[] }) {
+  const m = useMessages();
+  const [active, setActive] = useState(ALL);
+
+  // album id → its filter genres, computed once.
+  const genresByAlbum = useMemo(
+    () => new Map(albums.map((a) => [a.id, albumFilterGenres(a)])),
+    [albums]
+  );
+
+  // Tabs = "All" + each genre, most-used first (then alphabetical).
+  const tabs = useMemo<SectionTab[]>(() => {
+    const counts = new Map<string, number>();
+    for (const list of genresByAlbum.values()) {
+      for (const name of list) counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    const genres = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([name]) => ({ key: name, label: name }));
+    return [{ key: ALL, label: m.sections.all }, ...genres];
+  }, [genresByAlbum, m.sections.all]);
+
+  const visible =
+    active === ALL
+      ? albums
+      : albums.filter((a) => genresByAlbum.get(a.id)?.includes(active));
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.head}>
+        <SectionHeader
+          title={m.sections.albums}
+          tabs={tabs}
+          activeKey={active}
+          onSelect={setActive}
+        />
+      </div>
+      <div className={styles.grid}>
+        {visible.map((album) => (
+          <AlbumCard key={album.id} album={album} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SectionHeader.module.css
+++ b/src/components/SectionHeader.module.css
@@ -1,0 +1,54 @@
+/* Composites over the page background exactly like the site header: soft-grey
+   content renders pink through color-dodge. Keep no transform/opacity/isolation
+   on wrappers between this element and the body. */
+.header {
+  mix-blend-mode: color-dodge;
+  color: var(--header-fg);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  font-family: var(--font-gloock), serif;
+  font-size: 24px;
+  line-height: 29px;
+  font-weight: 400;
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--header-fg) 10%, transparent);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  flex-shrink: 0;
+  padding: 8px 16px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  white-space: nowrap;
+  color: var(--header-fg);
+  opacity: 0.8;
+  /* sit the active underline on top of the row's own bottom border */
+  border-bottom: 1px solid transparent;
+  margin-bottom: -1px;
+  transition: opacity 0.15s ease;
+}
+
+.tab:hover {
+  opacity: 1;
+}
+
+.active {
+  font-weight: 700;
+  opacity: 1;
+  border-bottom-color: var(--header-fg);
+}

--- a/src/components/SectionHeader.module.css
+++ b/src/components/SectionHeader.module.css
@@ -14,14 +14,22 @@
   font-size: 24px;
   line-height: 29px;
   font-weight: 400;
+  padding-inline: var(--section-pad, 0);
 }
 
 .tabs {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid color-mix(in srgb, var(--header-fg) 10%, transparent);
+  /* The row rule is an inset shadow rather than a border so the active tab's
+     underline can sit on the very same line without a `margin-bottom: -1px`
+     — which an overflow scroll container (below) would clip. */
+  box-shadow: inset 0 -1px 0 0
+    color-mix(in srgb, var(--header-fg) 10%, transparent);
   overflow-x: auto;
   scrollbar-width: none;
+  /* Full-bleed scroll: the inset lives inside the scroller, so tabs scroll all
+     the way to the true edge instead of being cut at a padded container edge. */
+  padding-inline: var(--section-pad, 0);
 }
 
 .tabs::-webkit-scrollbar {
@@ -37,9 +45,8 @@
   white-space: nowrap;
   color: var(--header-fg);
   opacity: 0.8;
-  /* sit the active underline on top of the row's own bottom border */
+  /* sits on the row rule; transparent keeps every tab the same height */
   border-bottom: 1px solid transparent;
-  margin-bottom: -1px;
   transition: opacity 0.15s ease;
 }
 

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import styles from "./SectionHeader.module.css";
+
+export type SectionTab = { key: string; label: string };
+
+type Props = {
+  title: string;
+  tabs: SectionTab[];
+  activeKey: string;
+  onSelect: (key: string) => void;
+};
+
+/**
+ * Home section header: the site-title font for the name plus a row of
+ * underlined tabs. Renders in `mix-blend-mode: color-dodge` (like the site
+ * header) so its soft-grey content composites to pink over the page.
+ */
+export default function SectionHeader({
+  title,
+  tabs,
+  activeKey,
+  onSelect,
+}: Props) {
+  return (
+    <div className={styles.header}>
+      <h2 className={styles.title}>{title}</h2>
+      <div className={styles.tabs} role="tablist" aria-label={title}>
+        {tabs.map((tab) => {
+          const active = tab.key === activeKey;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              className={`${styles.tab} ${active ? styles.active : ""}`}
+              onClick={() => onSelect(tab.key)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StandaloneTrack.module.css
+++ b/src/components/StandaloneTrack.module.css
@@ -1,0 +1,132 @@
+.track {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px 16px;
+}
+
+/* ---------- cover / play-pause ---------- */
+
+.cover {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  /* same asymmetric sleeve corners + drop shadow as the album cover art */
+  border-radius: 2px 4px 4px 2px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  color: var(--album-light);
+  /* palette backdrop so nothing shows through while the art loads */
+  background: linear-gradient(
+    135deg,
+    var(--album-deep),
+    color-mix(in srgb, var(--album-accent) 40%, var(--bg))
+  );
+}
+
+.cover:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.coverImg {
+  object-fit: cover;
+}
+
+.texture {
+  position: absolute;
+  inset: 0;
+  background: url("/cover-texture.png") center / cover;
+  mix-blend-mode: multiply;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* play affordance revealed on hover/focus — the resting state is just the art */
+.hint {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
+  color: var(--album-light);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.cover:hover .hint,
+.cover:focus-visible .hint {
+  opacity: 1;
+}
+
+.cover:disabled .hint {
+  display: none;
+}
+
+/* playing: the cover becomes the classical accent pause button */
+.playing {
+  background: var(--album-accent);
+  color: var(--album-light);
+}
+
+/* ---------- heading ---------- */
+
+.heading {
+  flex: 1 0 0;
+  min-width: 1px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.name {
+  color: var(--album-light);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+/* album name — same font props as the time */
+.album {
+  color: var(--album-deep);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+/* ---------- footer ---------- */
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.time {
+  color: var(--album-deep);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  min-width: 30px;
+  text-align: right;
+}
+
+/* ---------- description ---------- */
+
+.description {
+  width: 100%;
+  color: var(--album-light);
+  opacity: 0.5;
+  font-size: 16px;
+  line-height: 22px;
+}

--- a/src/components/StandaloneTrack.tsx
+++ b/src/components/StandaloneTrack.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Image from "next/image";
+import { Pause, Play } from "lucide-react";
+import { toPlayerTrack, usePlayer } from "@/player/PlayerProvider";
+import { formatTime } from "@/player/durations";
+import { getPalette, paletteVars } from "@/lib/palettes";
+import type { Track } from "@/lib/types";
+import LikeButton from "./LikeButton";
+import styles from "./StandaloneTrack.module.css";
+
+type Props = {
+  track: Track;
+  /** The surrounding tab's tracks — queued together on play. */
+  queue: Track[];
+};
+
+/**
+ * A track shown outside its album: the album cover doubles as the play control
+ * (it becomes a pause button while this track is playing), the heading pairs
+ * the track name with its album, and the description sits underneath like the
+ * detailed album-page row.
+ */
+export default function StandaloneTrack({ track, queue }: Props) {
+  const { current, isPlaying, toggle, playFrom } = usePlayer();
+  const palette = getPalette({
+    id: track.album_id ?? undefined,
+    name: track.album_name ?? undefined,
+    theme: track.album_theme ?? undefined,
+  });
+
+  const playable = Boolean(track.latest_resource_url);
+  const active = current?.id === track.track_id && isPlaying;
+
+  const onPlayClick = () => {
+    if (!playable) return;
+    if (current?.id === track.track_id) {
+      toggle();
+      return;
+    }
+    const playableTracks = queue.filter((t) => t.latest_resource_url);
+    playFrom(
+      playableTracks.map(toPlayerTrack),
+      playableTracks.findIndex((t) => t.track_id === track.track_id)
+    );
+  };
+
+  return (
+    <li className={styles.track} style={paletteVars(palette)}>
+      <div className={styles.header}>
+        <button
+          type="button"
+          className={`${styles.cover} ${active ? styles.playing : ""}`}
+          disabled={!playable}
+          aria-label={
+            active ? `Pause ${track.track_name}` : `Play ${track.track_name}`
+          }
+          onClick={onPlayClick}
+        >
+          {active ? (
+            <Pause size={20} strokeWidth={2} />
+          ) : (
+            <>
+              {track.album_cover_url && (
+                <Image
+                  src={track.album_cover_url}
+                  alt=""
+                  fill
+                  sizes="40px"
+                  className={styles.coverImg}
+                />
+              )}
+              <span className={styles.texture} />
+              <span className={styles.hint} aria-hidden>
+                <Play size={20} strokeWidth={2} />
+              </span>
+            </>
+          )}
+        </button>
+
+        <div className={styles.heading}>
+          <span className={`${styles.name} ${active ? "shimmer" : ""}`}>
+            {track.track_name}
+          </span>
+          {track.album_name && (
+            <span className={styles.album}>{track.album_name}</span>
+          )}
+        </div>
+
+        <div className={styles.footer}>
+          <span className={styles.time}>
+            {track.duration !== null ? formatTime(track.duration) : "–:–"}
+          </span>
+          <LikeButton
+            trackId={track.track_id}
+            likeCount={track.like_count ?? 0}
+          />
+        </div>
+      </div>
+
+      {track.track_description && (
+        <p className={styles.description}>{track.track_description}</p>
+      )}
+    </li>
+  );
+}

--- a/src/components/TracksSection.module.css
+++ b/src/components/TracksSection.module.css
@@ -1,0 +1,32 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid color-mix(in srgb, var(--header-fg) 8%, transparent);
+}
+
+.tracks {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  align-items: start;
+}
+
+@media (max-width: 1023px) {
+  .tracks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .section {
+    gap: 16px;
+    padding: 0 24px 24px;
+  }
+
+  .tracks {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 24px;
+  }
+}

--- a/src/components/TracksSection.module.css
+++ b/src/components/TracksSection.module.css
@@ -21,12 +21,16 @@
 
 @media (max-width: 767px) {
   .section {
+    /* horizontal inset for the header + track rows; the section stays
+       full-width so the header's tabs can scroll edge to edge */
+    --section-pad: 24px;
     gap: 16px;
-    padding: 0 24px 24px;
+    padding-bottom: 24px;
   }
 
   .tracks {
     grid-template-columns: minmax(0, 1fr);
     gap: 24px;
+    padding-inline: var(--section-pad);
   }
 }

--- a/src/components/TracksSection.tsx
+++ b/src/components/TracksSection.tsx
@@ -27,14 +27,12 @@ export default function TracksSection({ popular, latest }: Props) {
 
   return (
     <section className={styles.section}>
-      <div className={styles.head}>
-        <SectionHeader
-          title={m.sections.tracks}
-          tabs={tabs}
-          activeKey={tab}
-          onSelect={(key) => setTab(key as "popular" | "latest")}
-        />
-      </div>
+      <SectionHeader
+        title={m.sections.tracks}
+        tabs={tabs}
+        activeKey={tab}
+        onSelect={(key) => setTab(key as "popular" | "latest")}
+      />
       <ul className={styles.tracks}>
         {tracks.map((track) => (
           <StandaloneTrack

--- a/src/components/TracksSection.tsx
+++ b/src/components/TracksSection.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import type { Track } from "@/lib/types";
+import { useMessages } from "@/lib/i18n/LocaleProvider";
+import SectionHeader from "./SectionHeader";
+import StandaloneTrack from "./StandaloneTrack";
+import styles from "./TracksSection.module.css";
+
+type Props = {
+  popular: Track[];
+  latest: Track[];
+};
+
+/** Home "Tracks" section: standalone tracks under Popular / Latests tabs. */
+export default function TracksSection({ popular, latest }: Props) {
+  const m = useMessages();
+  const [tab, setTab] = useState<"popular" | "latest">("popular");
+
+  if (popular.length === 0 && latest.length === 0) return null;
+
+  const tracks = tab === "popular" ? popular : latest;
+  const tabs = [
+    { key: "popular", label: m.sections.popular },
+    { key: "latest", label: m.sections.latests },
+  ];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.head}>
+        <SectionHeader
+          title={m.sections.tracks}
+          tabs={tabs}
+          activeKey={tab}
+          onSelect={(key) => setTab(key as "popular" | "latest")}
+        />
+      </div>
+      <ul className={styles.tracks}>
+        {tracks.map((track) => (
+          <StandaloneTrack
+            key={track.track_id}
+            track={track}
+            queue={tracks}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "./supabase/anon";
 import {
   hasVersion,
+  trackPopularity,
   type Album,
   type AlbumWithTracks,
   type Genre,
@@ -104,10 +105,25 @@ async function attachAlbumThemes(
   }
 }
 
+/** Build an album_id → genres map from an `album_genres(genres(...))` join. */
+function groupGenres(
+  rows: { album_id: string; genres: Genre | null }[]
+): Map<string, Genre[]> {
+  const byAlbum = new Map<string, Genre[]>();
+  for (const row of rows) {
+    if (!row.genres) continue;
+    const list = byAlbum.get(row.album_id) ?? [];
+    list.push(row.genres);
+    byAlbum.set(row.album_id, list);
+  }
+  return byAlbum;
+}
+
 function groupTracks(
   albums: Album[],
   tracks: Track[],
-  position: Map<string, number>
+  position: Map<string, number>,
+  genresByAlbum: Map<string, Genre[]>
 ): AlbumWithTracks[] {
   const byAlbum = new Map<string, Track[]>();
   for (const track of tracks) {
@@ -128,12 +144,12 @@ function groupTracks(
   return albums.map((album) => ({
     ...album,
     tracks: byAlbum.get(album.id) ?? [],
-    genres: [],
+    genres: genresByAlbum.get(album.id) ?? [],
   }));
 }
 
 export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
-  const [albumsRes, tracksRes, orderRes] = await Promise.all([
+  const [albumsRes, tracksRes, orderRes, genresRes] = await Promise.all([
     supabase
       .from("albums")
       .select(ALBUM_COLS)
@@ -144,17 +160,29 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
       .not("album_id", "is", null)
       .order("latest_release_date", { ascending: false }),
     supabase.from("album_tracks").select("track_id,position"),
+    supabase.from("album_genres").select("album_id,genres(id,name,slug)"),
   ]);
 
   if (albumsRes.error) fail("Failed to load albums", albumsRes.error);
   if (tracksRes.error) fail("Failed to load tracks", tracksRes.error);
   if (orderRes.error) fail("Failed to load track order", orderRes.error);
+  // Genres are non-critical decoration (the home filter tabs fall back to the
+  // display genre); degrade to none rather than break the catalog.
+  if (genresRes.error) {
+    console.error("Failed to load album genres", genresRes.error.message);
+  }
 
   const position = new Map(
     (orderRes.data ?? []).map((r) => [
       r.track_id as string,
       r.position as number,
     ])
+  );
+  const genresByAlbum = groupGenres(
+    (genresRes.data ?? []) as unknown as {
+      album_id: string;
+      genres: Genre | null;
+    }[]
   );
 
   // Listener view: drop versionless tracks, then albums left with none. Owners
@@ -163,9 +191,61 @@ export async function getAlbumsWithTracks(): Promise<AlbumWithTracks[]> {
   const tracks = ((tracksRes.data ?? []) as Track[]).filter(hasVersion);
   attachThemesFromAlbums(albums, tracks);
   await attachDurations(supabase, tracks);
-  return groupTracks(albums, tracks, position).filter(
+  return groupTracks(albums, tracks, position, genresByAlbum).filter(
     (album) => album.tracks.length > 0
   );
+}
+
+/**
+ * Attach each track's total play count from the `track_play_counts` view.
+ * Non-critical (only feeds the "Popular" ranking); a missing view or error
+ * degrades every count to 0 rather than breaking the home page.
+ */
+async function attachPlayCounts(
+  client: SupabaseClient,
+  tracks: Track[]
+): Promise<void> {
+  const ids = [...new Set(tracks.map((t) => t.track_id))];
+  if (ids.length === 0) return;
+  const { data, error } = await client
+    .from("track_play_counts")
+    .select("track_id,play_count")
+    .in("track_id", ids);
+  if (error) {
+    console.error("Failed to load play counts", error.message);
+    for (const track of tracks) track.play_count = track.play_count ?? 0;
+    return;
+  }
+  const byId = new Map(
+    (data ?? []).map((row) => [
+      row.track_id as string,
+      Number(row.play_count) || 0,
+    ])
+  );
+  for (const track of tracks) track.play_count = byId.get(track.track_id) ?? 0;
+}
+
+/**
+ * Split a flat track list into the two home "Tracks" tabs:
+ *  - `popular`: the top 3 by {@link trackPopularity} (likes weighted over plays)
+ *  - `latest`:  the 3 most recently released (by the latest version's date)
+ * Play counts are attached here so the ranking has them.
+ */
+export async function getFeaturedTracks(
+  tracks: Track[],
+  limit = 3
+): Promise<{ popular: Track[]; latest: Track[] }> {
+  await attachPlayCounts(supabase, tracks);
+  const popular = [...tracks]
+    .sort((a, b) => trackPopularity(b) - trackPopularity(a))
+    .slice(0, limit);
+  const latest = [...tracks]
+    .filter((t) => t.latest_release_date)
+    .sort((a, b) =>
+      (b.latest_release_date ?? "").localeCompare(a.latest_release_date ?? "")
+    )
+    .slice(0, limit);
+  return { popular, latest };
 }
 
 export async function getAlbumWithTracks(

--- a/src/lib/genres.ts
+++ b/src/lib/genres.ts
@@ -1,0 +1,32 @@
+import type { AlbumWithTracks } from "./types";
+import { getPalette } from "./palettes";
+
+/**
+ * Album genre helpers, shared by the album cards (meta tile) and the home
+ * "Albums" filter tabs so both read the same value.
+ */
+
+function capitalize(value: string | null): string {
+  if (!value) return "Album";
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/** The single genre shown on an album's meta tile (legacy palette genre → type). */
+export function displayGenre(album: {
+  id?: string;
+  name?: string | null;
+  theme?: string | null;
+  type?: string | null;
+}): string {
+  return getPalette(album).genre ?? capitalize(album.type ?? null);
+}
+
+/**
+ * Genres an album is filed under for the home filter tabs. Prefers the real
+ * `album_genres` links; falls back to the single display genre so an album with
+ * no links assigned still lands under a meaningful tab.
+ */
+export function albumFilterGenres(album: AlbumWithTracks): string[] {
+  const linked = album.genres.map((g) => g.name);
+  return linked.length > 0 ? linked : [displayGenre(album)];
+}

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -9,6 +9,13 @@
  */
 export const en = {
   nav: { home: "Home", top: "Top", bio: "Bio" },
+  sections: {
+    tracks: "Tracks",
+    albums: "Albums",
+    popular: "Popular",
+    latests: "Latests",
+    all: "All",
+  },
   account: {
     triggerLabel: "Account menu",
     sectionAccount: "Account",

--- a/src/lib/i18n/messages/fr.ts
+++ b/src/lib/i18n/messages/fr.ts
@@ -6,6 +6,13 @@ import type { Messages } from "./en";
  */
 export const fr: Messages = {
   nav: { home: "Accueil", top: "Top", bio: "Bio" },
+  sections: {
+    tracks: "Morceaux",
+    albums: "Albums",
+    popular: "Populaires",
+    latests: "Récents",
+    all: "Tous",
+  },
   account: {
     triggerLabel: "Menu du compte",
     sectionAccount: "Compte",

--- a/src/lib/palettes.ts
+++ b/src/lib/palettes.ts
@@ -109,7 +109,7 @@ const LEGACY_GENRE: Record<string, string> = {
   Celesta: "Cinematic",
 };
 
-type AlbumLike = { id?: string; name?: string; theme?: string | null };
+type AlbumLike = { id?: string; name?: string | null; theme?: string | null };
 
 /** Resolve an album's palette: its stored theme, else the legacy match, else
     the default. `theme` may be absent when the caller only has id/name. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,12 @@ export type Track = {
    * (on upload, or by the backfill script for pre-existing rows).
    */
   duration: number | null;
+  /**
+   * Total recorded plays, attached by the data layer from the
+   * `track_play_counts` view. Only populated where a popularity ranking needs
+   * it (the home "Popular" tab); undefined elsewhere, treated as 0.
+   */
+  play_count?: number | null;
 };
 
 export type AlbumWithTracks = Album & {
@@ -70,6 +76,15 @@ export type AlbumWithTracks = Album & {
  */
 export function hasVersion(track: Track): boolean {
   return track.latest_version_id !== null;
+}
+
+/**
+ * Popularity score for the home "Popular" ranking: a like is worth 10 points,
+ * ten plays are worth 1 (i.e. one play = 0.1). So 3 likes + 20 plays = 32, and
+ * 1 like + 500 plays = 60.
+ */
+export function trackPopularity(track: Track): number {
+  return (track.like_count ?? 0) * 10 + (track.play_count ?? 0) * 0.1;
 }
 
 export type TrackLyrics = Record<string, string | null>;

--- a/supabase/migrations/20260715000000_track_play_counts.sql
+++ b/supabase/migrations/20260715000000_track_play_counts.sql
@@ -1,0 +1,17 @@
+-- Aggregate play counts per track, readable by anon + authenticated clients.
+--
+-- public.track_plays is locked down by RLS (a client may only read its own
+-- rows), so the raw table can't power a public "most played" ranking. This
+-- view aggregates it and — like the like_count aggregate exposed on the
+-- track_overview view — runs with the view owner's rights (security_invoker
+-- off), so it surfaces only per-track totals, never individual play rows,
+-- anonymous ids, or any other PII.
+--
+-- Powers the home "Popular" tab: popularity = like_count * 10 + play_count / 10.
+create or replace view public.track_play_counts
+  with (security_invoker = off) as
+  select track_id, count(*)::bigint as play_count
+  from public.track_plays
+  group by track_id;
+
+grant select on public.track_play_counts to anon, authenticated;


### PR DESCRIPTION
## Summary
Restructures the home page to feature a new **Tracks** section showcasing standalone tracks under Popular and Latest tabs, followed by the existing Albums section. The Popular tab ranks tracks by a weighted popularity score (likes × 10 + plays × 0.1), while Latest shows the most recently released tracks.

## Key Changes

- **New `StandaloneTrack` component** — Displays individual tracks outside their album context. The album cover doubles as a play/pause button (becomes a pause icon when playing), with the track name paired alongside its album name and duration. Includes a description below and integrates with the player for queue management.

- **New `TracksSection` component** — Home page section with tabbed interface (Popular/Latest) that renders a grid of `StandaloneTrack` components. Handles tab state and passes the appropriate track queue to each track.

- **New `SectionHeader` component** — Reusable header for home sections with a title (using the site's serif font) and underlined tabs. Uses `mix-blend-mode: color-dodge` to composite over the page background like the main header.

- **New `AlbumsSection` component** — Refactored albums grid into its own section with genre-based filter tabs. Dynamically generates tabs from album genres (most-used first, then alphabetical), with an "All" option to show every album.

- **New `getFeaturedTracks()` function** — Data layer function that splits tracks into Popular (top 3 by weighted score) and Latest (3 most recent) categories. Attaches play counts from the new `track_play_counts` view.

- **New `track_play_counts` view** — Database view that aggregates play counts per track from `track_plays` table. Runs with view owner's rights (security_invoker off) to expose only totals, never individual rows or PII.

- **New `trackPopularity()` function** — Ranking formula: `like_count × 10 + play_count × 0.1`. Weights engagement heavily toward likes while still considering play volume.

- **New `albumFilterGenres()` helper** — Determines which genres an album appears under in the Albums section tabs. Prefers explicit `album_genres` links; falls back to the display genre (from palette) if none are assigned.

- **Updated `getAlbumsWithTracks()`** — Now loads and attaches album genres from the `album_genres` join table, populating the `genres` field on each album.

- **Home page restructure** — Replaced simple album grid with two sections: Tracks (new) then Albums (refactored). Updated page styles to remove the old `.albums` grid class.

- **i18n additions** — Added section labels (Tracks, Albums, Popular, Latests, All) in English and French.

## Notable Implementation Details

- Play counts are non-critical decoration; if the view is missing or query fails, tracks degrade to 0 plays rather than breaking the page.
- The `StandaloneTrack` component queues all tracks in its tab together on play, allowing seamless navigation through the Popular or Latest list.
- Album genres are loaded once and memoized in `AlbumsSection` to avoid recomputing the filter tab list on every render.
- The `displayGenre()` function is extracted to a shared module so both album cards and the filter tabs read the same genre value.

https://claude.ai/code/session_015ZcLnoyAUpMfoJL8UKyuV5