### PR TITLE
Add expandable player details drawer with lyrics support

### DIFF
--- a/src/components/AlbumPlaylist.tsx
+++ b/src/components/AlbumPlaylist.tsx
@@ -24,6 +24,7 @@ export default function AlbumPlaylist({
           queue={tracks}
           variant={variant}
           lyrics={lyrics[track.track_id] ?? null}
+          queueLyrics={lyrics}
         />
       ))}
     </ul>

--- a/src/components/AlbumTrack.tsx
+++ b/src/components/AlbumTrack.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Mic, Pause, Play } from "lucide-react";
 import { toPlayerTrack, usePlayer } from "@/player/PlayerProvider";
 import { formatTime } from "@/player/durations";
-import type { Track } from "@/lib/types";
+import type { Track, TrackLyrics } from "@/lib/types";
 import LikeButton from "./LikeButton";
 import LyricsSheet from "./LyricsSheet";
 import styles from "./AlbumTrack.module.css";
@@ -15,6 +15,11 @@ type Props = {
   queue: Track[];
   variant?: "simple" | "detailed";
   lyrics?: string | null;
+  /**
+   * Lyrics keyed by track id for the whole `queue`, so each queued entry
+   * carries its lyrics into the global player's expanded view.
+   */
+  queueLyrics?: TrackLyrics;
 };
 
 export default function AlbumTrack({
@@ -22,6 +27,7 @@ export default function AlbumTrack({
   queue,
   variant = "simple",
   lyrics = null,
+  queueLyrics,
 }: Props) {
   const { current, isPlaying, toggle, playFrom } = usePlayer();
   const duration = track.duration;
@@ -39,7 +45,7 @@ export default function AlbumTrack({
     }
     const playableTracks = queue.filter((t) => t.latest_resource_url);
     playFrom(
-      playableTracks.map(toPlayerTrack),
+      playableTracks.map((t) => toPlayerTrack(t, queueLyrics?.[t.track_id] ?? null)),
       playableTracks.findIndex((t) => t.track_id === track.track_id)
     );
   };

--- a/src/components/PlayerBar.module.css
+++ b/src/components/PlayerBar.module.css
@@ -86,11 +86,19 @@
   align-items: center;
 }
 
+/* The meta block doubles as the drawer toggle — tapping the vinyl or the
+   track name expands the player. Inherits the global button reset. */
 .meta {
   display: flex;
   align-items: center;
   gap: 16px;
   min-width: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.meta:disabled {
+  cursor: default;
 }
 
 /* The album's vinyl disc replaces the flat cover — it turns gently while the
@@ -117,6 +125,23 @@
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  flex: 1;
+}
+
+/* Disclosure affordance for the expandable details drawer; rotates when open. */
+.chevron {
+  flex-shrink: 0;
+  color: var(--album-accent);
+  opacity: 0.5;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.2s ease;
+}
+
+.meta:hover .chevron {
+  opacity: 0.85;
+}
+
+.bar[data-expanded="true"] .chevron {
+  transform: rotate(180deg);
 }
 
 .trackName {
@@ -222,11 +247,85 @@
   }
 }
 
+/* Expandable details drawer. The 0fr → 1fr grid row animates the height
+   fluidly with no magic max-height; the inner content fades and settles in
+   just behind it. The card is bottom-anchored, so it grows gently upward. */
+.expansion {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.42s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.bar[data-expanded="true"] .expansion {
+  grid-template-rows: 1fr;
+}
+
+.expansionClip {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.expansionInner {
+  margin: 0 24px;
+  padding: 14px 0 16px;
+  border-top: 1px solid color-mix(in srgb, var(--album-light) 10%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.bar[data-expanded="true"] .expansionInner {
+  opacity: 1;
+  transform: none;
+  transition-delay: 0.06s;
+}
+
+.description {
+  color: var(--album-light);
+  opacity: 0.62;
+  font-size: 14px;
+  line-height: 20px;
+  max-width: 680px;
+}
+
+.expandActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.expandButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: var(--radius-button);
+  background: color-mix(in srgb, var(--album-accent) 14%, transparent);
+  color: var(--album-light);
+  font-size: 13px;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
+.expandButton:hover {
+  background: color-mix(in srgb, var(--album-accent) 24%, transparent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .disc[data-playing="true"],
   .bar[data-playing="true"]::before,
   .bar[data-playing="true"] .playButton {
     animation: none;
+  }
+
+  .expansion,
+  .expansionInner,
+  .chevron {
+    transition: none;
   }
 }
 
@@ -251,5 +350,19 @@
   .timeline {
     grid-area: timeline;
     gap: 12px;
+  }
+
+  /* Reclaim room for the track name: drop the skip buttons and keep just
+     repeat + play/pause, with repeat on the left and the pause on the right. */
+  .stepButton {
+    display: none;
+  }
+
+  .repeatButton {
+    order: -1;
+  }
+
+  .expansionInner {
+    margin: 0 16px;
   }
 }

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import {
+  ChevronDown,
+  Disc3,
+  Mic,
   Pause,
   Play,
   Repeat,
@@ -13,6 +17,8 @@ import type WaveSurfer from "wavesurfer.js";
 import { getPalette, paletteVars } from "@/lib/palettes";
 import { formatTime } from "@/player/durations";
 import { usePlayer } from "@/player/PlayerProvider";
+import { useMessages } from "@/lib/i18n/LocaleProvider";
+import LyricsSheet from "./LyricsSheet";
 import VinylDisc from "./VinylDisc";
 import styles from "./PlayerBar.module.css";
 
@@ -59,11 +65,29 @@ function alpha(hex: string, fraction: number): string {
 export default function PlayerBar() {
   const player = usePlayer();
   const { current, isPlaying, repeat, time, duration } = player;
+  const m = useMessages();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const wsRef = useRef<WaveSurfer | null>(null);
   const loadedUrl = useRef<string | null>(null);
   const [wsReady, setWsReady] = useState(false);
+
+  // Expanded details drawer (description + Album/Lyrics actions), toggled by
+  // tapping the vinyl or the track name.
+  const [expanded, setExpanded] = useState(false);
+  const [lyricsOpen, setLyricsOpen] = useState(false);
+
+  // A freshly-started track always appears collapsed: reset the drawer whenever
+  // the current track changes (or the bar hides). Adjusting state during render
+  // — rather than in an effect — is React's recommended way to reset on a
+  // changing value, and avoids a cascading re-render.
+  const trackId = current?.id ?? null;
+  const [shownTrackId, setShownTrackId] = useState(trackId);
+  if (trackId !== shownTrackId) {
+    setShownTrackId(trackId);
+    setExpanded(false);
+    setLyricsOpen(false);
+  }
 
   // the seek callback changes identity across renders; the wavesurfer
   // 'interaction' handler is registered once, so it reads through a ref
@@ -138,83 +162,145 @@ export default function PlayerBar() {
     wsRef.current?.setTime(time);
   }, [time]);
 
+  const hasLyrics = Boolean(current?.lyrics);
+  const canExpand = Boolean(current);
+
   return (
-    <div
-      className={styles.bar}
-      data-player-visible={current ? "true" : "false"}
-      data-playing={isPlaying ? "true" : "false"}
-      aria-hidden={current ? undefined : true}
-      style={palette ? paletteVars(palette) : undefined}
-    >
-      <div className={styles.inner}>
-        <div className={styles.meta}>
-          <div className={styles.disc} data-playing={isPlaying ? "true" : "false"}>
-            <VinylDisc coverUrl={current?.coverUrl ?? null} size={48} />
-          </div>
-          <div className={styles.titles}>
-            <span
-              className={`${styles.trackName} ${isPlaying ? "shimmer" : ""}`}
-            >
-              {current?.name}
+    <>
+      <div
+        className={styles.bar}
+        data-player-visible={current ? "true" : "false"}
+        data-playing={isPlaying ? "true" : "false"}
+        data-expanded={expanded ? "true" : "false"}
+        aria-hidden={current ? undefined : true}
+        style={palette ? paletteVars(palette) : undefined}
+      >
+        <div className={styles.inner}>
+          <button
+            type="button"
+            className={styles.meta}
+            aria-expanded={expanded}
+            title={expanded ? m.player.collapse : m.player.expand}
+            disabled={!canExpand}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <div className={styles.disc} data-playing={isPlaying ? "true" : "false"}>
+              <VinylDisc coverUrl={current?.coverUrl ?? null} size={48} />
+            </div>
+            <div className={styles.titles}>
+              <span
+                className={`${styles.trackName} ${isPlaying ? "shimmer" : ""}`}
+              >
+                {current?.name}
+              </span>
+              <span className={styles.albumName}>{current?.albumName}</span>
+            </div>
+            <ChevronDown
+              className={styles.chevron}
+              size={18}
+              strokeWidth={2}
+              aria-hidden
+            />
+          </button>
+
+          <div className={styles.timeline}>
+            <span className={styles.time}>{formatTime(time)}</span>
+            <div ref={containerRef} className={styles.waveform} />
+            <span className={styles.time}>
+              {duration > 0 ? formatTime(duration) : "–:–"}
             </span>
-            <span className={styles.albumName}>{current?.albumName}</span>
+          </div>
+
+          <div className={styles.controls}>
+            <button
+              type="button"
+              className={`${styles.controlButton} ${styles.stepButton}`}
+              aria-label="Previous track"
+              onClick={player.previous}
+            >
+              <SkipBack size={20} strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              className={styles.playButton}
+              aria-label={isPlaying ? "Pause" : "Play"}
+              onClick={player.toggle}
+            >
+              {isPlaying ? (
+                <Pause size={20} strokeWidth={2} />
+              ) : (
+                <Play size={20} strokeWidth={2} />
+              )}
+            </button>
+            <button
+              type="button"
+              className={`${styles.controlButton} ${styles.stepButton}`}
+              aria-label="Next track"
+              onClick={player.next}
+            >
+              <SkipForward size={20} strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              className={`${styles.controlButton} ${styles.repeatButton} ${
+                repeat === "none" ? styles.repeatOff : ""
+              }`}
+              aria-label={`Repeat mode: ${repeat}`}
+              title={`Repeat: ${repeat}`}
+              onClick={player.cycleRepeat}
+            >
+              {repeat === "one" ? (
+                <Repeat1 size={20} strokeWidth={2} />
+              ) : (
+                <Repeat size={20} strokeWidth={2} />
+              )}
+            </button>
           </div>
         </div>
 
-        <div className={styles.timeline}>
-          <span className={styles.time}>{formatTime(time)}</span>
-          <div ref={containerRef} className={styles.waveform} />
-          <span className={styles.time}>
-            {duration > 0 ? formatTime(duration) : "–:–"}
-          </span>
-        </div>
-
-        <div className={styles.controls}>
-          <button
-            type="button"
-            className={styles.controlButton}
-            aria-label="Previous track"
-            onClick={player.previous}
-          >
-            <SkipBack size={20} strokeWidth={2} />
-          </button>
-          <button
-            type="button"
-            className={styles.playButton}
-            aria-label={isPlaying ? "Pause" : "Play"}
-            onClick={player.toggle}
-          >
-            {isPlaying ? (
-              <Pause size={20} strokeWidth={2} />
-            ) : (
-              <Play size={20} strokeWidth={2} />
-            )}
-          </button>
-          <button
-            type="button"
-            className={styles.controlButton}
-            aria-label="Next track"
-            onClick={player.next}
-          >
-            <SkipForward size={20} strokeWidth={2} />
-          </button>
-          <button
-            type="button"
-            className={`${styles.controlButton} ${
-              repeat === "none" ? styles.repeatOff : ""
-            }`}
-            aria-label={`Repeat mode: ${repeat}`}
-            title={`Repeat: ${repeat}`}
-            onClick={player.cycleRepeat}
-          >
-            {repeat === "one" ? (
-              <Repeat1 size={20} strokeWidth={2} />
-            ) : (
-              <Repeat size={20} strokeWidth={2} />
-            )}
-          </button>
+        <div className={styles.expansion}>
+          <div className={styles.expansionClip}>
+            <div className={styles.expansionInner}>
+              {current?.description && (
+                <p className={styles.description}>{current.description}</p>
+              )}
+              <div className={styles.expandActions}>
+                {current?.albumId && (
+                  <Link
+                    href={`/albums/${current.albumId}`}
+                    className={styles.expandButton}
+                    onClick={() => setExpanded(false)}
+                  >
+                    <Disc3 size={16} strokeWidth={2} aria-hidden />
+                    {m.player.album}
+                  </Link>
+                )}
+                {hasLyrics && (
+                  <button
+                    type="button"
+                    className={styles.expandButton}
+                    onClick={() => setLyricsOpen(true)}
+                  >
+                    <Mic size={16} strokeWidth={2} aria-hidden />
+                    {m.player.lyrics}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+
+      {hasLyrics && current && (
+        <div style={palette ? paletteVars(palette) : undefined}>
+          <LyricsSheet
+            open={lyricsOpen}
+            onClose={() => setLyricsOpen(false)}
+            trackName={current.name}
+            lyrics={current.lyrics ?? ""}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/edit/VersionsSection.tsx
+++ b/src/components/edit/VersionsSection.tsx
@@ -246,6 +246,8 @@ export default function VersionsSection({
         albumName: album.name,
         coverUrl: album.cover_url,
         theme: album.theme,
+        description: track.description,
+        lyrics: track.lyrics,
       })),
       playable.findIndex((v) => v.id === version.id)
     );

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -19,6 +19,12 @@ export const en = {
     signOut: "Sign out",
   },
   profile: { nameFallback: "You" },
+  player: {
+    expand: "Show track details",
+    collapse: "Hide track details",
+    album: "Album",
+    lyrics: "Lyrics",
+  },
   likes: {
     title: "My likes",
     empty:

--- a/src/lib/i18n/messages/fr.ts
+++ b/src/lib/i18n/messages/fr.ts
@@ -16,6 +16,12 @@ export const fr: Messages = {
     signOut: "Se déconnecter",
   },
   profile: { nameFallback: "Vous" },
+  player: {
+    expand: "Afficher les détails du titre",
+    collapse: "Masquer les détails du titre",
+    album: "Album",
+    lyrics: "Paroles",
+  },
   likes: {
     title: "Mes favoris",
     empty:

--- a/src/player/PlayerProvider.tsx
+++ b/src/player/PlayerProvider.tsx
@@ -22,6 +22,14 @@ export type PlayerTrack = {
   coverUrl: string | null;
   /** Album theme key, so the player resolves the same palette as the album. */
   theme: string | null;
+  /** Track blurb shown in the player's expanded details drawer. */
+  description: string | null;
+  /**
+   * Track lyrics. Not part of the `track_overview` view, so callers that have
+   * them (the album page) pass them through; null everywhere else, which hides
+   * the expanded player's Lyrics action.
+   */
+  lyrics: string | null;
 };
 
 export type RepeatMode = "none" | "one" | "all";
@@ -47,8 +55,15 @@ type PlayerContextValue = {
 
 const PlayerContext = createContext<PlayerContextValue | null>(null);
 
-/** Map a `track_overview` row (with a playable URL) to a queue entry. */
-export function toPlayerTrack(track: Track): PlayerTrack {
+/**
+ * Map a `track_overview` row (with a playable URL) to a queue entry. Lyrics
+ * live outside the view, so callers that have them (the album page) pass them
+ * in; they default to null so the player's Lyrics action simply stays hidden.
+ */
+export function toPlayerTrack(
+  track: Track,
+  lyrics: string | null = null
+): PlayerTrack {
   return {
     id: track.track_id,
     name: track.track_name,
@@ -57,6 +72,8 @@ export function toPlayerTrack(track: Track): PlayerTrack {
     albumName: track.album_name,
     coverUrl: track.album_cover_url,
     theme: track.album_theme ?? null,
+    description: track.track_description,
+    lyrics,
   };
 }
 


### PR DESCRIPTION
## Summary
Enhances the player bar with an expandable details drawer that displays track descriptions and provides quick access to album and lyrics views. The drawer toggles by tapping the vinyl disc or track name and smoothly animates open/closed with a disclosure chevron affordance.

## Key Changes

- **Expandable player drawer**: Added collapsible section below the player controls that displays track description and action buttons for album and lyrics
- **Lyrics sheet integration**: Integrated `LyricsSheet` component into the player, triggered from the expanded drawer when lyrics are available
- **Track metadata expansion**: Extended `PlayerTrack` type to include `description` and `lyrics` fields, allowing rich track information to flow through the player
- **Queue lyrics propagation**: Modified `AlbumTrack` and `AlbumPlaylist` to pass lyrics for all queued tracks into the player, so each track carries its lyrics into the global player's expanded view
- **UI/UX improvements**:
  - Added chevron icon that rotates when drawer is expanded
  - Made the meta section (vinyl + track name) a clickable button to toggle expansion
  - Smooth grid-based height animation for the drawer using `0fr` → `1fr` transition
  - Staggered fade-in animation for drawer content
  - Responsive adjustments: on mobile, hides skip buttons to reclaim space
- **Internationalization**: Added player-specific messages (expand, collapse, album, lyrics) in English and French
- **State management**: Implemented drawer state that resets when the current track changes, using React's recommended pattern of adjusting state during render

## Implementation Details

- The expansion drawer uses CSS Grid's `0fr`/`1fr` technique for fluid height animation without magic `max-height` values
- Drawer content fades and translates in with a slight delay after the height animation begins
- The `toPlayerTrack` helper now accepts optional lyrics parameter, defaulting to null for backward compatibility
- Track descriptions and lyrics are optional; the Lyrics action only appears when lyrics are present

https://claude.ai/code/session_01E5hvSRAgHRVi6A6T4nAFka