### PR TITLE
Refactor map callback to explicit arrow function in StandaloneTrack

### DIFF
--- a/src/components/StandaloneTrack.tsx
+++ b/src/components/StandaloneTrack.tsx
@@ -40,7 +40,7 @@ export default function StandaloneTrack({ track, queue }: Props) {
     }
     const playableTracks = queue.filter((t) => t.latest_resource_url);
     playFrom(
-      playableTracks.map(toPlayerTrack),
+      playableTracks.map((t) => toPlayerTrack(t)),
       playableTracks.findIndex((t) => t.track_id === track.track_id)
     );
   };


### PR DESCRIPTION
## Summary
Updated the `map` callback in StandaloneTrack component to use an explicit arrow function syntax for improved code clarity and consistency.

## Key Changes
- Changed `playableTracks.map(toPlayerTrack)` to `playableTracks.map((t) => toPlayerTrack(t))` to use an explicit arrow function wrapper instead of passing the function reference directly

## Implementation Details
This refactoring makes the callback more explicit and easier to understand at a glance. While functionally equivalent, the explicit arrow function syntax `(t) => toPlayerTrack(t)` is more readable than the implicit function reference `toPlayerTrack`, especially for developers who may be less familiar with higher-order function patterns.

https://claude.ai/code/session_01BrXVWrov5KQBNq9gtFr7yo