### PR TITLE
Wire the Ariko Lab Note pipeline

### DIFF
--- a/.github/workflows/lab-note.yml
+++ b/.github/workflows/lab-note.yml
@@ -1,0 +1,13 @@
+name: lab-note
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  lab-note:
+    if: github.event.pull_request.merged == true
+    uses: alexisbohns/ariko/.github/workflows/lab-note.yml@main
+    secrets:
+      inbox_token: ${{ secrets.ARIKO_INBOX_TOKEN }}


### PR DESCRIPTION
## Summary

Wires melogram into Ariko's [Lab Note pipeline](https://github.com/alexisbohns/ariko#lab-note-pipeline-c1--github-connector). Adds the ~10-line `.github/workflows/lab-note.yml` stub that calls the reusable Ariko workflow whenever a PR merges. From now on, merging a user-facing PR whose body carries a `## Lab Note` section files a bilingual changelog capture into the Ariko vault automatically — the only human action is the merge.

This PR is the bootstrap: the workflow lands on the merge ref, so merging this very PR fires it and posts the Lab Note below as end-to-end proof.

Resolves #120

## Lab Note

```yaml
en:
  title: Melogram files its own changelog
  summary: Merged user-facing PRs now post a bilingual Lab Note into the Ariko vault automatically — the only human action is merging.
fr:
  title: Melogram tient son propre journal
  summary: Les PR fusionnées touchant l'expérience utilisateur publient désormais une note bilingue dans le coffre Ariko — il suffit de fusionner.
suggested:
  molecule: melogram
  atom: lab-note-pipeline
  type: feature
  tags: [changelog, automation, ci]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
